### PR TITLE
Consolidate Dependabot Change Note Workflow

### DIFF
--- a/.github/workflows/dependabot-changenote.yml
+++ b/.github/workflows/dependabot-changenote.yml
@@ -1,0 +1,44 @@
+name: Dependabot Change Note
+
+on:
+  workflow_call:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  changenote:
+    name: Dependabot Change Note
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          token: ${{ secrets.BRUTUS_PAT_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config --local user.email "$(git log --pretty='%ae' -1)"
+          git config --local user.name "Dependabot[bot]"
+
+      - name: Commit Change Note
+        run: |
+          # Fetch PR number for commit from Github API
+          API_URL="${{ github.api_url }}/repos/${{ github.repository }}/commits/${{ github.event.head_commit.id }}/pulls"
+          PR_NUM=$(curl -s -H "Accept: application/vnd.github+json" "${API_URL}" | jq -r '.[].number')
+          
+          # Create change note from first line of dependabot commit
+          NEWS=$(printf "%s" "${{ github.event.head_commit.message }}" | head -n1 | sed -e 's/Bump/Updated/')
+          printf "%s.\n" "${NEWS}" > "./changes/${PR_NUM}.misc.rst"
+          
+          # Commit the change note
+          git add "./changes/${PR_NUM}.misc.rst"
+          # "dependabot skip" tells Dependabot to continue rebasing this branch despite foreign commits
+          git commit -m "Add changenote. [dependabot skip]"
+
+      - name: Push
+        run: git push origin


### PR DESCRIPTION
## Dependabot Change Note
I sourced `dependabot-changenote.yml` from `rubicon-objc` since it includes the `printf` fix.

This turned out even easier than I expected. The workflow below is all that'll be necessary for a repo to add dependabot change notes (once this PR is merged).

```yaml
name: Dependabot Change Note

on:
  push:
    branches:
      - 'dependabot/**'

jobs:
  changenote:
    name: Dependabot Change Note
    uses: beeware/.github/.github/workflows/dependabot-changenote.yml@main
    secrets: inherit
```

Example PR: https://github.com/rmartin16/briefcase-test-1/pull/6
Change note workflow run: https://github.com/rmartin16/briefcase-test-1/actions/runs/3653055359

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
