### PR TITLE
Enable dependabot on the dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates on Sunday, 8PM UTC
+      interval: "weekly"
+      day: "sunday"
+      time: "20:00"

--- a/.github/workflows/dependabot-changenote.yml
+++ b/.github/workflows/dependabot-changenote.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   changenote:
     name: Dependabot Change Note
-    if: github.actor == 'dependabot[bot]'
+    if: github.actor == 'dependabot[bot]' && github.repository != 'beeware/.github'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -30,11 +30,11 @@ jobs:
           # Fetch PR number for commit from Github API
           API_URL="${{ github.api_url }}/repos/${{ github.repository }}/commits/${{ github.event.head_commit.id }}/pulls"
           PR_NUM=$(curl -s -H "Accept: application/vnd.github+json" "${API_URL}" | jq -r '.[].number')
-          
+
           # Create change note from first line of dependabot commit
           NEWS=$(printf "%s" "${{ github.event.head_commit.message }}" | head -n1 | sed -e 's/Bump/Updated/')
           printf "%s.\n" "${NEWS}" > "./changes/${PR_NUM}.misc.rst"
-          
+
           # Commit the change note
           git add "./changes/${PR_NUM}.misc.rst"
           # "dependabot skip" tells Dependabot to continue rebasing this branch despite foreign commits

--- a/changes/README.md
+++ b/changes/README.md
@@ -1,0 +1,1 @@
+Automatic changenotes will be added here.

--- a/changes/README.md
+++ b/changes/README.md
@@ -1,1 +1,0 @@
-Automatic changenotes will be added here.


### PR DESCRIPTION
The shared Dependabot CI workflow added by #2 will also need to be updated by dependabot.

There's a chicken-and-egg problem here; this repo defines a dependabot workflow to add change notes; which means there is a workflow that needs tone updated by dependabot. However, this repo *doesn't* use towncrier (since there's nothing to release). To allow for this, an empty placeholder directory has been added where change notes can be written (and then ignored)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
