### PR TITLE
Install Context-specific Version of Briefcase

### DIFF
--- a/.github/actions/install-briefcase/action.yml
+++ b/.github/actions/install-briefcase/action.yml
@@ -1,0 +1,79 @@
+name: Install Briefcase
+description: Installs a version of Briefcase appropriate for the context.
+
+inputs:
+  briefcase-url:
+    description: "URL to Briefcase git repository."
+    default: "https://github.com/beeware/briefcase.git"
+  briefcase-default-branch:
+    description: "Briefcase's default branch."
+    default: "main"
+  briefcase-override-version:
+    description: "Override version l"
+
+runs:
+  using: composite
+  steps:
+
+    - name: Derive Target Briefcase Version
+      id: briefcase
+      shell: bash
+      run: |
+        # Branch or tag that triggered the workflow.
+        # For example, when github.event is:
+        #  push:         refs/heads/<branch_name>
+        #                refs/tags/<tag_name>
+        #  pull_request: refs/pull/<pr_number>/merge
+        #  release:      refs/tags/<tag_name>
+        TRIGGER_REF="${{ github.ref }}"
+
+        # PR target branch (only available for pull requests)
+        PR_TARGET_REF="${{ github.base_ref }}"
+        
+        echo "::group::Workflow Trigger Details"
+        echo "Event:    ${{ github.event_name }}"
+        echo "Ref:      ${{ github.ref }}"
+        echo "Base Ref: ${{ github.base_ref }}"
+        echo "Head Ref: ${{ github.head_ref }}"
+        echo "Ref Name: ${{ github.ref_name }}"
+        echo "::endgroup::"
+
+        case "${TRIGGER_REF}" in
+          
+          # Not a PR; use branch or tag name
+          refs/tags/* | refs/heads/* )
+            TARGET_VERSION="${{ github.ref_name	}}"
+            ;;
+        
+          # Is a PR; use target branch name
+          refs/pull/* )
+            TARGET_VERSION="${PR_TARGET_REF/refs\/heads\//}"
+            ;;
+        
+          # Default to 'main'
+          * )
+            echo "::warning::Could not determine Briefcase version from '${TRIGGER_REF}'; defaulting to '${{ inputs.briefcase-default-branch }}'."
+            TARGET_VERSION="${{ inputs.briefcase-default-branch }}"
+            ;;
+
+        esac
+
+        echo "Derived Briefcase version: ${TARGET_VERSION}"
+        
+        # Use Briefcase's default branch 
+        if [[ "${TARGET_VERSION}" == "${{ inputs.briefcase-default-branch }}" ]]; then
+          echo "version=${TARGET_VERSION}" >> ${GITHUB_OUTPUT}
+        
+        # Use version if it is a valid Briefcase tag
+        elif [[ $(git ls-remote --tags "${{ inputs.briefcase-url }}" "${TARGET_VERSION}") ]]; then
+          echo "version=${TARGET_VERSION}" >> ${GITHUB_OUTPUT}
+        
+        # Default to Briefcase's default branch
+        else
+          echo "::warning::Unknown Briefcase version: '${TARGET_VERSION}'; defaulting to '${{ inputs.briefcase-default-branch }}'."
+          echo "version=${{ inputs.briefcase-default-branch }}" >> ${GITHUB_OUTPUT}
+        fi
+
+    - name: Install Briefcase
+      shell: bash
+      run: python -m pip install -U git+${{ inputs.briefcase-url }}@${{ steps.briefcase.outputs.version }}

--- a/.github/actions/install-briefcase/action.yml
+++ b/.github/actions/install-briefcase/action.yml
@@ -9,7 +9,19 @@ inputs:
     description: "Briefcase's default branch."
     default: "main"
   briefcase-override-version:
-    description: "Override version l"
+    description: "Version of Briefcase to install without it being derived; e.g. v0.3.12"
+    required: false
+  testing-pr-ref:
+    description: "Override value for github.base_ref; only for testing."
+    required: false
+  testing-ref-name:
+    description: "Override value for github.ref_name; only for testing."
+    required: false
+
+outputs:
+  installed-version:
+    value: ${{ steps.briefcase.outputs.version }}
+    description: "The version of Briefcase that was installed."
 
 runs:
   using: composite
@@ -25,10 +37,15 @@ runs:
         #                refs/tags/<tag_name>
         #  pull_request: refs/pull/<pr_number>/merge
         #  release:      refs/tags/<tag_name>
-        TRIGGER_REF="${{ github.ref }}"
+        TRIGGER_REF="${{ inputs.briefcase-override-version }}"
+        TRIGGER_REF="${TRIGGER_REF:-${{ github.ref }}}"
 
         # PR target branch (only available for pull requests)
-        PR_TARGET_REF="${{ github.base_ref }}"
+        PR_TARGET_REF="${{ inputs.testing-pr-ref }}"
+        PR_TARGET_REF="${PR_TARGET_REF:-${{ github.base_ref }}}"
+
+        REF_NAME="${{ inputs.testing-ref-name }}"
+        REF_NAME="${REF_NAME:-${{ github.ref_name }}}"
         
         echo "::group::Workflow Trigger Details"
         echo "Event:    ${{ github.event_name }}"
@@ -39,10 +56,15 @@ runs:
         echo "::endgroup::"
 
         case "${TRIGGER_REF}" in
+
+          # Use override version
+          v* | main | ${{ inputs.briefcase-default-branch }} )
+            TARGET_VERSION="${TRIGGER_REF}"
+            ;;
           
           # Not a PR; use branch or tag name
           refs/tags/* | refs/heads/* )
-            TARGET_VERSION="${{ github.ref_name	}}"
+            TARGET_VERSION="${REF_NAME}"
             ;;
         
           # Is a PR; use target branch name

--- a/.github/workflows/test-install-briefcase.yml
+++ b/.github/workflows/test-install-briefcase.yml
@@ -1,0 +1,82 @@
+name: Test Action install-briefcase
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test-install-briefcase:
+    name: Install Briefcase
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        version:
+        - "v0.3.12"
+        - "main"
+        - "40.0.5"
+        - "refs/tags/v0.3.11"
+        - "refs/tags/v40.0.5"
+        - "refs/heads/v0.3.10"
+        - "refs/heads/v40.0.5"
+        - "refs/pull/v0.3.9"
+        - "refs/pull/v40.0.5"
+        include:
+        - version: "v0.3.12"
+          expected: "v0.3.12"
+        - version: "main"
+          expected: "main"
+        - version: "40.0.5"
+          expected: "main"
+        - version: "refs/tags/v0.3.11"
+          testing-ref-name: "v0.3.11"
+          expected: "v0.3.11"
+        - version: "refs/tags/v40.0.5"
+          testing-ref-name: "v40.0.5"
+          expected: "main"
+        - version: "refs/heads/v0.3.10"
+          testing-ref-name: "v0.3.10"
+          expected: "v0.3.10"
+        - version: "refs/heads/v40.0.5"
+          testing-ref-name: "v40.0.5"
+          expected: "main"
+        - version: "refs/pull/v0.3.9"
+          testing-pr-ref: "refs/heads/v0.3.9"
+          expected: "v0.3.9"
+        - version: "refs/pull/v0.3.9"
+          testing-pr-ref: "v0.3.9"
+          expected: "v0.3.9"
+        - version: "refs/pull/v40.0.5"
+          testing-pr-ref: "v40.0.5"
+          expected: "main"
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4.5.0
+      with:
+        python-version: 3.X
+
+    - name: Install Briefcase
+      id: briefcase
+      uses: ./.github/actions/install-briefcase
+      with:
+        briefcase-override-version: "${{ matrix.version }}"
+        testing-pr-ref: "${{ matrix.testing-pr-ref }}"
+        testing-ref-name: "${{ matrix.testing-ref-name }}"
+
+    - name: Test Briefcase @ ${{ matrix.version }}
+      run: |
+        if [[ "${{ matrix.expected }}" != "${{ steps.briefcase.outputs.installed-version }}" ]]; then
+          echo "installed-version: ${{ steps.briefcase.outputs.installed-version }}"
+          echo "Found Briefcase version v$(briefcase -V)"
+          echo "Expected Briefcase version ${{ matrix.expected }}"
+          exit 1
+        fi


### PR DESCRIPTION
In several CI runs, we need to install Briefcase; however, the appropriate version to install is dependent on the context.

- When CI runs on the `main` branch in a repo, Briefcase should be installed from its `main` branch.
  - Example: https://github.com/rmartin16/briefcase-windows-app-template-test-1/actions/runs/4086765608/jobs/7049375420
- When CI runs for an arbitrary branch, Briefcase should be installed using branch as version.
  - Example for `v0.3.11` branch: https://github.com/rmartin16/briefcase-windows-app-template-test-1/actions/runs/4087055913/jobs/7049392731
  - Example for `v10.0.0` branch: https://github.com/rmartin16/briefcase-windows-app-template-test-1/actions/runs/4087072170/jobs/7049409704
- When CI runs for a tag, Briefcase should be installed using the tag version.
  - Example for `v40.10.6` tag: https://github.com/rmartin16/briefcase-windows-app-template-test-1/actions/runs/4087695409/jobs/7049424029
  - Example for `v0.3.12` tag: https://github.com/rmartin16/briefcase-windows-app-template-test-1/actions/runs/4087711584/jobs/7049438896
- When CI runs for a PR, Briefcase should be installed using PR's target branch version.
  - For instance, when a PR for a template is targeting the `v0.3.12` branch, the `v0.3.12` version of Briefcase should be installed.
  - Example for `main` branch: https://github.com/rmartin16/briefcase-windows-app-template-test-1/actions/runs/4086946506/jobs/7049469167
    - Of note, we are _really_ close to the maximum windows path length (hence the build failures) 😟 
  - Example for `v0.3.11` branch: https://github.com/rmartin16/briefcase-windows-app-template-test-1/actions/runs/4086976986/jobs/7049493706
  - Example for `v10.0.0` branch: https://github.com/rmartin16/briefcase-windows-app-template-test-1/actions/runs/4087022947/jobs/7049517402
    - Briefcase's `main` branch is used when the version is unknown.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
