### PR TITLE
Add a fallback for cron invocation of pre-commit-update trigger.

### DIFF
--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -54,7 +54,7 @@ jobs:
           python-version: 3.X
 
       - name: Install pre-commit
-        run: python -m pip install ${{ inputs.pre-commit-source }}
+        run: python -m pip install ${{ inputs.pre-commit-source || pre-commit }}
 
       - name: Update pre-commit hooks
         run: |

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -54,7 +54,7 @@ jobs:
           python-version: 3.X
 
       - name: Install pre-commit
-        run: python -m pip install ${{ inputs.pre-commit-source || pre-commit }}
+        run: python -m pip install ${{ inputs.pre-commit-source || 'pre-commit' }}
 
       - name: Update pre-commit hooks
         run: |


### PR DESCRIPTION
When pre-commit-update is triggered on a cron, it doesn't have a `pre-commit-source` input, so it fails because the input evaluates as "". This falls back to `pre-commit` when there isn't a value. Calls via `workflow-call` have `.[dev]` as a default.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
