### PR TITLE
Build Flatpak for frameworks other than toga

### DIFF
--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -195,7 +195,6 @@ jobs:
         startsWith(inputs.runner-os, 'ubuntu')
         && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
         && contains(fromJSON('["", "Flatpak"]'), inputs.target-format)
-        && startsWith(inputs.framework, 'toga')
       run: |
         sudo apt-get update -y
         sudo apt-get install -y flatpak flatpak-builder


### PR DESCRIPTION
When I created `app-build-verify.yml`, I limited Flatpak builds to Ubuntu and toga because that's what Briefcase was doing. However, now I'm beginning to think this was a copy/paste leftover and wasn't actually intended.

This PR removes the limitation of `framework==toga` for building Flatpaks.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
