### PR TITLE
Add app verification tests for Linux system packages.

### DIFF
--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -99,7 +99,7 @@ jobs:
 
     - name: Determine default system python3 version
       run: |
-        echo "SYSTEM_PYTHON_VERSION=$(python3 -c 'import sys; print(f\"{sys.version_info.major}.{sys.version_info.minor}\")')" >> $GITHUB_ENV
+        echo "SYSTEM_PYTHON_VERSION=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')" >> $GITHUB_ENV
 
     - name: Set up Python
       if: inputs.python-source == 'github'

--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -193,6 +193,10 @@ jobs:
         && contains(fromJSON('["", "system"]'), inputs.target-format)
         && ${{ inputs.python-version == '3.10' }}
       run: |
+        echo "RUNNER OS ${{ inputs.runner-os }}"
+        echo "TARGET PLATFORM ${{ inputs.target-platform }}"
+        echo "TARGET FORMAT ${{ inputs.target-format }}"
+        echo "PYTHON VERSION ${{ inputs.python-version }}"
         cd tests/apps/verify-${{ inputs.framework }}
         briefcase create linux system
         briefcase build linux system

--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -186,7 +186,7 @@ jobs:
         briefcase build windows VisualStudio
         briefcase package windows VisualStudio --adhoc-sign
 
-    - name: Build Linux System project
+    - name: Build Linux System project (Debian, local)
       if: |
         startsWith(inputs.runner-os, 'ubuntu')
         && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
@@ -197,7 +197,7 @@ jobs:
         briefcase build linux system
         briefcase package linux system --adhoc-sign
 
-    - name: Build Linux System project (Dockerized)
+    - name: Build Linux System project (RPM, Dockerized)
       if: |
         startsWith(inputs.runner-os, 'ubuntu')
         && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
@@ -207,6 +207,18 @@ jobs:
         briefcase create linux system --target fedora:37
         briefcase build linux system --target fedora:37
         briefcase package linux system --target fedora:37 --adhoc-sign
+
+    - name: Build Linux System project (Arch, Dockerized)
+      if: |
+        startsWith(inputs.runner-os, 'ubuntu')
+        && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
+        && contains(fromJSON('["", "system"]'), inputs.target-format)
+      run: |
+        cd tests/apps/verify-${{ inputs.framework }}
+        briefcase create linux system --target archlinux:latest
+        briefcase build linux system --target archlinux:latest
+        # FIXME: Arch packaging not supported (yet!)
+        # briefcase package linux system --target archlinux:latest --adhoc-sign
 
     - name: Build AppImage project
       if: |

--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -186,16 +186,28 @@ jobs:
         briefcase build windows VisualStudio
         briefcase package windows VisualStudio --adhoc-sign
 
-    - name: Build Linux System project (Debian, local)
+    - name: Build Linux System project (Ubuntu, local)
+      if: |
+        startsWith(inputs.runner-os, 'ubuntu')
+        && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
+        && contains(fromJSON('["", "system"]'), inputs.target-format)
+        && ${{ inputs.python-version == '3.10' }}
+      run: |
+        cd tests/apps/verify-${{ inputs.framework }}
+        briefcase create linux system
+        briefcase build linux system
+        briefcase package linux system --adhoc-sign
+
+    - name: Build Linux System project (Debian, Dockerized)
       if: |
         startsWith(inputs.runner-os, 'ubuntu')
         && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
         && contains(fromJSON('["", "system"]'), inputs.target-format)
       run: |
         cd tests/apps/verify-${{ inputs.framework }}
-        briefcase create linux system
-        briefcase build linux system
-        briefcase package linux system --adhoc-sign
+        briefcase create linux system --target debian:bullseye
+        briefcase build linux system --target debian:bullseye
+        briefcase package linux system --target debian:bullseye --adhoc-sign
 
     - name: Build Linux System project (RPM, Dockerized)
       if: |

--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -189,14 +189,10 @@ jobs:
     - name: Build Linux System project (Ubuntu, local)
       if: |
         startsWith(inputs.runner-os, 'ubuntu')
+        && startsWith(inputs.python-version, '3.10')
         && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
         && contains(fromJSON('["", "system"]'), inputs.target-format)
-        && ${{ inputs.python-version == '3.10' }}
       run: |
-        echo "RUNNER OS ${{ inputs.runner-os }}"
-        echo "TARGET PLATFORM ${{ inputs.target-platform }}"
-        echo "TARGET FORMAT ${{ inputs.target-format }}"
-        echo "PYTHON VERSION ${{ inputs.python-version }}"
         cd tests/apps/verify-${{ inputs.framework }}
         briefcase create linux system
         briefcase build linux system

--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -97,6 +97,10 @@ jobs:
           ${{ steps.dirs.outputs.pip-cache-dir }}
           ${{ steps.dirs.outputs.docker-cache-dir }}
 
+    - name: Determine default system python3 version
+      run: |
+        echo "SYSTEM_PYTHON_VERSION=$(python3 -c 'import sys; print(f\"{sys.version_info.major}.{sys.version_info.minor}\")')" >> $GITHUB_ENV
+
     - name: Set up Python
       if: inputs.python-source == 'github'
       uses: actions/setup-python@v4.5.0
@@ -189,7 +193,7 @@ jobs:
     - name: Build Linux System project (Ubuntu, local)
       if: |
         startsWith(inputs.runner-os, 'ubuntu')
-        && startsWith(inputs.python-version, '3.10')
+        && startsWith(inputs.python-version, ${{ env.SYSTEM_PYTHON_VERSION }})
         && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
         && contains(fromJSON('["", "system"]'), inputs.target-format)
       run: |

--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -193,6 +193,7 @@ jobs:
         && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
         && contains(fromJSON('["", "system"]'), inputs.target-format)
       run: |
+        sudo apt-get update -y && sudo apt-get install -y python3-dev python3-pip libcairo2-dev libgirepository1.0-dev
         cd tests/apps/verify-${{ inputs.framework }}
         briefcase create linux system
         briefcase build linux system

--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -97,9 +97,11 @@ jobs:
           ${{ steps.dirs.outputs.pip-cache-dir }}
           ${{ steps.dirs.outputs.docker-cache-dir }}
 
-    - name: Determine default system python3 version
+    - name: Determine system python3 version
+      id: system-python
       run: |
-        echo "SYSTEM_PYTHON_VERSION=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')" >> $GITHUB_ENV
+        echo "python-version=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+        echo "python-version=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')" >> ${GITHUB_OUTPUT}
 
     - name: Set up Python
       if: inputs.python-source == 'github'
@@ -193,7 +195,7 @@ jobs:
     - name: Build Linux System project (Ubuntu, local)
       if: |
         startsWith(inputs.runner-os, 'ubuntu')
-        && startsWith(inputs.python-version, ${{ env.SYSTEM_PYTHON_VERSION }})
+        && startsWith(inputs.python-version, steps.system-python.outputs.python-version)
         && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
         && contains(fromJSON('["", "system"]'), inputs.target-format)
       run: |

--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -186,6 +186,28 @@ jobs:
         briefcase build windows VisualStudio
         briefcase package windows VisualStudio --adhoc-sign
 
+    - name: Build Linux System project
+      if: |
+        startsWith(inputs.runner-os, 'ubuntu')
+        && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
+        && contains(fromJSON('["", "system"]'), inputs.target-format)
+      run: |
+        cd tests/apps/verify-${{ inputs.framework }}
+        briefcase create linux system
+        briefcase build linux system
+        briefcase package linux system --adhoc-sign
+
+    - name: Build Linux System project (Dockerized)
+      if: |
+        startsWith(inputs.runner-os, 'ubuntu')
+        && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
+        && contains(fromJSON('["", "system"]'), inputs.target-format)
+      run: |
+        cd tests/apps/verify-${{ inputs.framework }}
+        briefcase create linux system --target fedora:37
+        briefcase build linux system --target fedora:37
+        briefcase package linux system --target fedora:37 --adhoc-sign
+
     - name: Build AppImage project
       if: |
         startsWith(inputs.runner-os, 'ubuntu')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
     uses: ./.github/workflows/app-build-verify.yml
     with:
       # This *must* be the version of Python that is the system Python on ubuntu-latest.
-      # Otherwise native system package builds won't succeed.
+      # Otherwise native system package builds won't be included.
       python-version: "3.10"
       repository: beeware/briefcase
       runner-os: ${{ matrix.runner-os }}
@@ -191,7 +191,9 @@ jobs:
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      python-version: "3.9"
+      # This *must* be the version of Python that is the system Python on ubuntu-latest.
+      # Otherwise native system package builds won't be included.
+      python-version: "3.10"
       repository: beeware/briefcase-template
       briefcase-template-source: "../../"
       runner-os: ${{ matrix.runner-os }}
@@ -229,6 +231,24 @@ jobs:
       target-platform: iOS
       target-format: xcode
       framework: toga
+
+  test-verify-apps-linux-system-templates:
+    name: Test Verify Linux System App
+    needs: pre-commit
+    uses: ./.github/workflows/app-build-verify.yml
+    with:
+      # This *must* be the version of Python that is the system Python on ubuntu-latest.
+      # Otherwise native system package builds won't be included.
+      python-version: "3.10"
+      repository: beeware/briefcase-linux-appimage-template
+      runner-os: ubuntu-latest
+      target-platform: linux
+      target-format: system
+      framework: ${{ matrix.framework }}
+    strategy:
+      fail-fast: false
+      matrix:
+        framework: [ "toga", "pyside2", "pyside6", "ppb" ]
 
   test-verify-apps-appimage-templates:
     name: Test Verify AppImage App

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        framework: [ "toga", "pyside2", "pyside6", "ppb" ]
+        framework: [ "toga", "ppb" ]
 
   test-verify-apps-appimage-templates:
     name: Test Verify AppImage App
@@ -264,7 +264,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        framework: [ "toga", "pyside2", "pyside6", "ppb" ]
+        framework: [ "toga", "ppb" ]
 
   test-verify-apps-flatpak-templates:
     name: Test Verify Flatpak App
@@ -293,7 +293,7 @@ jobs:
       fail-fast: false
       matrix:
         format: [ "app", "Xcode" ]
-        framework: [ "toga", "pyside2", "pyside6", "ppb" ]
+        framework: [ "toga", "ppb" ]
 
   test-verify-apps-web-templates:
     name: Test Verify Web App
@@ -323,5 +323,5 @@ jobs:
       fail-fast: false
       matrix:
         format: [ "app", "VisualStudio" ]
-        framework: [ "toga", "pyside2", "pyside6", "ppb" ]
+        framework: [ "toga", "ppb" ]
         python-source: [ "github", "winstore" ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,9 +174,7 @@ jobs:
     needs: [pre-commit, test-package-python]
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      # This *must* be the version of Python that is the system Python on ubuntu-latest.
-      # Otherwise native system package builds won't be included.
-      python-version: "3.10"
+      python-version: "3.9"
       repository: beeware/briefcase
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
@@ -191,9 +189,7 @@ jobs:
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      # This *must* be the version of Python that is the system Python on ubuntu-latest.
-      # Otherwise native system package builds won't be included.
-      python-version: "3.10"
+      python-version: "3.9"
       repository: beeware/briefcase-template
       briefcase-template-source: "../../"
       runner-os: ${{ matrix.runner-os }}
@@ -237,11 +233,11 @@ jobs:
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      # This *must* be the version of Python that is the system Python on ubuntu-latest.
+      # This *must* be the version of Python that is the system Python on ubuntu-22.04.
       # Otherwise native system package builds won't be included.
       python-version: "3.10"
       repository: beeware/briefcase-linux-system-template
-      runner-os: ubuntu-latest
+      runner-os: ubuntu-22.04
       target-platform: linux
       target-format: system
       framework: ${{ matrix.framework }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        framework: [ "toga", "pyside2", "pyside6", "ppb" ]
+        framework: [ "toga", "ppb" ]
         runner-os: [ "macos-latest", "windows-latest", "ubuntu-latest" ]
 
   test-verify-apps-briefcase-template:
@@ -201,7 +201,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        framework: [ "toga", "pyside2", "pyside6", "ppb" ]
+        framework: [ "toga", "ppb" ]
         runner-os: [ "macos-latest", "windows-latest", "ubuntu-latest" ]
 
   test-verify-apps-android-templates:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,9 @@ jobs:
     needs: [pre-commit, test-package-python]
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      python-version: "3.9"
+      # This *must* be the version of Python that is the system Python on ubuntu-latest.
+      # Otherwise native system package builds won't succeed.
+      python-version: "3.10"
       repository: beeware/briefcase
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,7 @@ jobs:
       # This *must* be the version of Python that is the system Python on ubuntu-latest.
       # Otherwise native system package builds won't be included.
       python-version: "3.10"
-      repository: beeware/briefcase-linux-appimage-template
+      repository: beeware/briefcase-linux-system-template
       runner-os: ubuntu-latest
       target-platform: linux
       target-format: system


### PR DESCRIPTION
Add Linux system package builds to the verification pipeline.

Adds 3 new app verification targets:
* An Ubuntu package (built outside docker)
* A Fedora package (built in Docker)
* An Arch package (build in Docker)

The packaging steps have been disable (for now) because Briefcase doesn't support them. They should be enabled once beeware/briefcase#1063 and beeware/briefcase#1064 have been completed.

Refs beeware/briefcase#1106.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
