### PR TITLE
Retrieve Briefcase to install from PR body

### DIFF
--- a/.github/actions/install-briefcase/action.yml
+++ b/.github/actions/install-briefcase/action.yml
@@ -26,9 +26,33 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Use Specified Briefcase Version
+      id: briefcase-override
+      shell: bash
+      run: |
+        set +o pipefail
+
+        # Source version from Body of PR
+        API_URL="${{ github.api_url }}/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}"
+        PR_BODY=$(curl -s -H "Accept: application/vnd.github+json" "${API_URL}" | jq -r '.body')
+        BRIEFCASE_REPO=$(printf "%s" "${PR_BODY}" | grep -oP "BRIEFCASE_REPO:\s*\K\S+" | head -n1)
+        BRIEFCASE_REF=$(printf "%s" "${PR_BODY}" | grep -oP "BRIEFCASE_REF:\s*\K\S+" | head -n1)
+
+        # If a version is not in the PR, use inputs specified in CI workflow
+        if [ -z "${BRIEFCASE_REPO}" ]; then
+          BRIEFCASE_REPO="${{ inputs.briefcase-url }}"
+        fi
+        if [ -z "${BRIEFCASE_REF}" ]; then
+          BRIEFCASE_REF="${{ inputs.briefcase-override-version }}"
+        fi
+
+        # Expose repo and version via outputs
+        echo "repo=${BRIEFCASE_REPO}" >> ${GITHUB_OUTPUT}
+        echo "ref=${BRIEFCASE_REF}" >> ${GITHUB_OUTPUT}
 
     - name: Derive Target Briefcase Version
       id: briefcase
+      if: steps.briefcase-override.outputs.ref == ''
       shell: bash
       run: |
         # Branch or tag that triggered the workflow.
@@ -37,8 +61,8 @@ runs:
         #                refs/tags/<tag_name>
         #  pull_request: refs/pull/<pr_number>/merge
         #  release:      refs/tags/<tag_name>
-        TRIGGER_REF="${{ inputs.briefcase-override-version }}"
-        TRIGGER_REF="${TRIGGER_REF:-${{ github.ref }}}"
+
+        TRIGGER_REF="${{ github.ref }}"
 
         # PR target branch (only available for pull requests)
         PR_TARGET_REF="${{ inputs.testing-pr-ref }}"
@@ -57,12 +81,7 @@ runs:
 
         case "${TRIGGER_REF}" in
 
-          # Use override version
-          v* | main | ${{ inputs.briefcase-default-branch }} )
-            TARGET_VERSION="${TRIGGER_REF}"
-            ;;
-
-          # Not a PR; use branch or tag name
+          # Not a PR; use current branch or tag name
           refs/tags/* | refs/heads/* )
             TARGET_VERSION="${REF_NAME}"
             ;;
@@ -102,4 +121,11 @@ runs:
 
     - name: Install Briefcase
       shell: bash
-      run: python -m pip install -U git+${{ inputs.briefcase-url }}@${{ steps.briefcase.outputs.version }}
+      run: |
+        REPO="${{ steps.briefcase-override.outputs.repo }}"
+        REPO="${REPO:-${{ inputs.briefcase-url }}}"
+
+        REF="${{ steps.briefcase-override.outputs.ref }}"
+        REF="${REF:-${{ steps.briefcase.outputs.version }}}"
+
+        python -m pip install -U "git+${REPO}@${REF}"

--- a/.github/actions/install-briefcase/action.yml
+++ b/.github/actions/install-briefcase/action.yml
@@ -11,6 +11,12 @@ inputs:
   briefcase-override-version:
     description: "Version of Briefcase to install without it being derived; e.g. v0.3.12"
     required: false
+  testing-pr-body:
+    description: "Override value for body of PR; only for testing."
+    required: false
+  testing-trigger-ref:
+    description: "Override value for github.ref; only for testing."
+    required: false
   testing-pr-ref:
     description: "Override value for github.base_ref; only for testing."
     required: false
@@ -20,7 +26,7 @@ inputs:
 
 outputs:
   installed-version:
-    value: ${{ steps.briefcase.outputs.version }}
+    value: ${{ steps.install.outputs.version }}
     description: "The version or branch of Briefcase that was installed."
 
 runs:
@@ -33,10 +39,13 @@ runs:
         set +o pipefail  # prevent grep failing the step if repo/ref isn't found
 
         # Source version from Body of PR
-        API_URL="${{ github.api_url }}/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}"
-        PR_BODY=$(curl -s -H "Accept: application/vnd.github+json" "${API_URL}" | jq -r '.body')
-        BRIEFCASE_REPO=$(printf "%s" "${PR_BODY}" | grep -ioP "BRIEFCASE[-_]*REPO:\s*\K\w+" | head -n1)
-        BRIEFCASE_REF=$(printf "%s" "${PR_BODY}" | grep -ioP "BRIEFCASE[-_]*REF:\s*\K\w+" | head -n1)
+        PR_BODY="${{ inputs.testing-pr-body }}"
+        if [ -z "${PR_BODY}" ]; then
+          API_URL="${{ github.api_url }}/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}"
+          PR_BODY=$(curl -s -H "Accept: application/vnd.github+json" "${API_URL}" | jq -r '.body')
+        fi
+        BRIEFCASE_REPO=$(printf "%s" "${PR_BODY}" | grep -ioP "BRIEFCASE[-_]*REPO:\s*\K\S+" | head -n1)
+        BRIEFCASE_REF=$(printf "%s" "${PR_BODY}" | grep -ioP "BRIEFCASE[-_]*REF:\s*\K\S+" | head -n1)
 
         # If a version is not in the PR, use inputs specified in CI workflow
         if [ -z "${BRIEFCASE_REPO}" ]; then
@@ -51,25 +60,27 @@ runs:
         echo "ref=${BRIEFCASE_REF}" >> ${GITHUB_OUTPUT}
 
     - name: Derive Target Briefcase Version
-      id: briefcase
+      id: briefcase-derived
       if: steps.briefcase-override.outputs.ref == ''
       shell: bash
       run: |
         # Branch or tag that triggered the workflow.
-        # For example, when github.event is:
-        #  push:         refs/heads/<branch_name>
-        #                refs/tags/<tag_name>
-        #  pull_request: refs/pull/<pr_number>/merge
-        #  release:      refs/tags/<tag_name>
-
-        TRIGGER_REF="${{ github.ref }}"
+        #  For example, when github.event is:
+        #   push:         refs/heads/<branch_name>
+        #                 refs/tags/<tag_name>
+        #   release:      refs/tags/<tag_name>
+        #   pull_request: refs/pull/<pr_number>/merge
+        TRIGGER_REF="${{ inputs.testing-trigger-ref || github.ref }}"
 
         # PR target branch (only available for pull requests)
-        PR_TARGET_REF="${{ inputs.testing-pr-ref }}"
-        PR_TARGET_REF="${PR_TARGET_REF:-${{ github.base_ref }}}"
+        PR_TARGET_REF="${{ inputs.testing-pr-ref || github.base_ref }}"
 
-        REF_NAME="${{ inputs.testing-ref-name }}"
-        REF_NAME="${REF_NAME:-${{ github.ref_name }}}"
+        # The short ref name of the branch or tag that triggered the workflow
+        #  For example:
+        #   push:         main
+        #   release:      v0.3.12
+        #   pull_request: 18/merge
+        REF_NAME="${{ inputs.testing-ref-name || github.ref_name }}"
 
         echo "::group::Workflow Trigger Details"
         echo "Event:    ${{ github.event_name }}"
@@ -120,8 +131,14 @@ runs:
       run: python -m pip install -U pip
 
     - name: Install Briefcase
+      id: install
       shell: bash
       run: |
         REPO="${{ steps.briefcase-override.outputs.repo || inputs.briefcase-url }}"
-        REF="${{ steps.briefcase-override.outputs.ref || steps.briefcase.outputs.version }}"
+        REF="${{ steps.briefcase-override.outputs.ref || steps.briefcase-derived.outputs.version }}"
+
+        echo "Installing ${REPO}@${REF}"
         python -m pip install -U "git+${REPO}@${REF}"
+
+        echo "Installed version: $(briefcase --version)"
+        echo "version=${REF}" >> ${GITHUB_OUTPUT}

--- a/.github/actions/install-briefcase/action.yml
+++ b/.github/actions/install-briefcase/action.yml
@@ -30,13 +30,13 @@ runs:
       id: briefcase-override
       shell: bash
       run: |
-        set +o pipefail
+        set +o pipefail  # prevent grep failing the step if repo/ref isn't found
 
         # Source version from Body of PR
         API_URL="${{ github.api_url }}/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}"
         PR_BODY=$(curl -s -H "Accept: application/vnd.github+json" "${API_URL}" | jq -r '.body')
-        BRIEFCASE_REPO=$(printf "%s" "${PR_BODY}" | grep -oP "BRIEFCASE_REPO:\s*\K\S+" | head -n1)
-        BRIEFCASE_REF=$(printf "%s" "${PR_BODY}" | grep -oP "BRIEFCASE_REF:\s*\K\S+" | head -n1)
+        BRIEFCASE_REPO=$(printf "%s" "${PR_BODY}" | grep -ioP "BRIEFCASE[-_]*REPO:\s*\K\w+" | head -n1)
+        BRIEFCASE_REF=$(printf "%s" "${PR_BODY}" | grep -ioP "BRIEFCASE[-_]*REF:\s*\K\w+" | head -n1)
 
         # If a version is not in the PR, use inputs specified in CI workflow
         if [ -z "${BRIEFCASE_REPO}" ]; then
@@ -122,10 +122,6 @@ runs:
     - name: Install Briefcase
       shell: bash
       run: |
-        REPO="${{ steps.briefcase-override.outputs.repo }}"
-        REPO="${REPO:-${{ inputs.briefcase-url }}}"
-
-        REF="${{ steps.briefcase-override.outputs.ref }}"
-        REF="${REF:-${{ steps.briefcase.outputs.version }}}"
-
+        REPO="${{ steps.briefcase-override.outputs.repo || inputs.briefcase-url }}"
+        REF="${{ steps.briefcase-override.outputs.ref || steps.briefcase.outputs.version }}"
         python -m pip install -U "git+${REPO}@${REF}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version:
+        test-case:
         - "v0.3.12"
         - "main"
-        - "40.0.5"
+        - "PR Repo & Ref"
+        - "PR Repo & Ref (irregular)"
+        - "PR Ref"
         - "refs/tags/v0.3.11"
         - "refs/tags/v40.0.5"
         - "refs/heads/v0.3.10"
@@ -40,31 +42,51 @@ jobs:
         - "refs/pull/v0.3.9"
         - "refs/pull/v40.0.5"
         include:
-        - version: "v0.3.12"
+        # Test override logic
+        - test-case: "v0.3.12"
+          version: "v0.3.12"
           expected: "v0.3.12"
-        - version: "main"
+        - test-case: "main"
+          version: "main"
           expected: "main"
-        - version: "40.0.5"
-          expected: "main"
-        - version: "refs/tags/v0.3.11"
+        # Test PR body override
+        - test-case: "PR Repo & Ref"
+          testing-pr-body: "sadf asdf BRIEFCASE_REPO: https://github.com/freakboy3742/briefcase.git xcvbwer BRIEFCASE_REF: 3470d95 xczvb"
+          expected: "3470d95"
+        - test-case: "PR Repo & Ref (irregular)"
+          testing-pr-body: "sadf asdf BrIeFcAsE__REpo: https://github.com/freakboy3742/briefcase.git xcvbwer BRIEFcaseREF:3470d95 xczvb"
+          expected: "3470d95"
+        - test-case: "PR Ref"
+          testing-pr-body: "sadf asdf BRIEFcaseREF: v0.3.12"
+          expected: "v0.3.12"
+        # Test version derivation for Releases
+        - test-case: "refs/tags/v0.3.11"
+          testing-trigger-ref: "refs/tags/v0.3.11"
           testing-ref-name: "v0.3.11"
           expected: "v0.3.11"
-        - version: "refs/tags/v40.0.5"
+        - test-case: "refs/tags/v40.0.5"
+          testing-trigger-ref: "refs/tags/v40.0.5"
           testing-ref-name: "v40.0.5"
           expected: "main"
-        - version: "refs/heads/v0.3.10"
+        - test-case: "refs/heads/v0.3.10"
+          testing-trigger-ref: "refs/heads/v0.3.10"
           testing-ref-name: "v0.3.10"
           expected: "v0.3.10"
-        - version: "refs/heads/v40.0.5"
+        - test-case: "refs/heads/v40.0.5"
+          testing-trigger-ref: "refs/heads/v40.0.5"
           testing-ref-name: "v40.0.5"
           expected: "main"
-        - version: "refs/pull/v0.3.9"
+        # Test version derivation for PRs
+        - test-case: "refs/pull/v0.3.9"
+          testing-trigger-ref: "refs/pull/18/merge"
           testing-pr-ref: "refs/heads/v0.3.9"
           expected: "v0.3.9"
-        - version: "refs/pull/v0.3.9"
+        - test-case: "refs/pull/v0.3.9"
+          testing-trigger-ref: "refs/pull/20/merge"
           testing-pr-ref: "v0.3.9"
           expected: "v0.3.9"
-        - version: "refs/pull/v40.0.5"
+        - test-case: "refs/pull/v40.0.5"
+          testing-trigger-ref: "refs/pull/25/merge"
           testing-pr-ref: "v40.0.5"
           expected: "main"
     steps:
@@ -81,10 +103,12 @@ jobs:
       uses: ./.github/actions/install-briefcase
       with:
         briefcase-override-version: ${{ matrix.version }}
+        testing-pr-body: ${{ matrix.testing-pr-body }}
+        testing-trigger-ref: ${{ matrix.testing-trigger-ref }}
         testing-pr-ref: ${{ matrix.testing-pr-ref }}
         testing-ref-name: ${{ matrix.testing-ref-name }}
 
-    - name: Test Briefcase @ ${{ matrix.version }}
+    - name: Test Briefcase @ ${{ matrix.test-case }}
       run: |
         if [[ "${{ matrix.expected }}" != "${{ steps.briefcase.outputs.installed-version }}" ]]; then
           echo "installed-version: ${{ steps.briefcase.outputs.installed-version }}"


### PR DESCRIPTION
Updates `install-briefcase` action to pull Briefcase repo and git ref from the body of the PR.

The PR can contain `BRIEFCASE[_]REPO: <repo>` and/or `BRIEFCASE[_]REF: <ref>` to control which version of Briefcase is used in CI. (Exclude brackets in the actual use-cases....needed here to avoid them being used...)

Example PR: https://github.com/rmartin16/briefcase-windows-app-template-test-1/pull/5

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
