### PR TITLE
Use `perl` for regex for `install-briefcase`

### DIFF
--- a/.github/actions/install-briefcase/action.yml
+++ b/.github/actions/install-briefcase/action.yml
@@ -36,16 +36,18 @@ runs:
       id: briefcase-override
       shell: bash
       run: |
-        set +o pipefail  # prevent grep failing the step if repo/ref isn't found
-
         # Source version from Body of PR
         PR_BODY="${{ inputs.testing-pr-body }}"
         if [ -z "${PR_BODY}" ]; then
           API_URL="${{ github.api_url }}/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}"
-          PR_BODY=$(curl -s -H "Accept: application/vnd.github+json" "${API_URL}" | jq -r '.body')
+          API_RESPONSE=$(curl -s -H "Accept: application/vnd.github+json" "${API_URL}")
+          echo "::group::GitHub API Response"
+          echo "${API_RESPONSE}"
+          echo "::endgroup::"
+          PR_BODY=$(printf "%s" "${API_RESPONSE}" | jq -r '.body')
         fi
-        BRIEFCASE_REPO=$(printf "%s" "${PR_BODY}" | grep -ioP "BRIEFCASE[-_]*REPO:\s*\K\S+" | head -n1)
-        BRIEFCASE_REF=$(printf "%s" "${PR_BODY}" | grep -ioP "BRIEFCASE[-_]*REF:\s*\K\S+" | head -n1)
+        BRIEFCASE_REPO=$(printf "%s" "${PR_BODY}" | perl -wlne '/BRIEFCASE[-_]*REPO:\s*\K\S+/i and print $&')
+        BRIEFCASE_REF=$(printf "%s" "${PR_BODY}" | perl -wlne '/BRIEFCASE[-_]*REF:\s*\K\S+/i and print $&')
 
         # If a version is not in the PR, use inputs specified in CI workflow
         if [ -z "${BRIEFCASE_REPO}" ]; then
@@ -56,6 +58,8 @@ runs:
         fi
 
         # Expose repo and version via outputs
+        echo "Briefcase Repo: ${BRIEFCASE_REPO}"
+        echo "Briefcase Ref: ${BRIEFCASE_REF}"
         echo "repo=${BRIEFCASE_REPO}" >> ${GITHUB_OUTPUT}
         echo "ref=${BRIEFCASE_REF}" >> ${GITHUB_OUTPUT}
 


### PR DESCRIPTION
Since `grep -P` is not valid for BSD grep (and whatever is installed on Windows), updated to just use `perl` directly.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
