### PR TITLE
Use authentication when hitting the Github API.

### DIFF
--- a/.github/actions/install-briefcase/action.yml
+++ b/.github/actions/install-briefcase/action.yml
@@ -43,7 +43,7 @@ runs:
         PR_BODY="${{ inputs.testing-pr-body }}"
         if [ -z "${PR_BODY}" ]; then
           API_URL="${{ github.api_url }}/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}"
-          API_RESPONSE=$(curl -s -H "authorization: Bearer ${{ secrets.github-token }}" -H "Accept: application/vnd.github+json" "${API_URL}")
+          API_RESPONSE=$(curl -s -H "authorization: Bearer ${{ inputs.github-token }}" -H "Accept: application/vnd.github+json" "${API_URL}")
           echo "::group::GitHub API Response"
           echo "${API_RESPONSE}"
           echo "::endgroup::"

--- a/.github/actions/install-briefcase/action.yml
+++ b/.github/actions/install-briefcase/action.yml
@@ -40,7 +40,7 @@ runs:
         PR_BODY="${{ inputs.testing-pr-body }}"
         if [ -z "${PR_BODY}" ]; then
           API_URL="${{ github.api_url }}/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}"
-          API_RESPONSE=$(curl -s -H "Accept: application/vnd.github+json" "${API_URL}")
+          API_RESPONSE=$(curl -s -H "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github+json" "${API_URL}")
           echo "::group::GitHub API Response"
           echo "${API_RESPONSE}"
           echo "::endgroup::"

--- a/.github/actions/install-briefcase/action.yml
+++ b/.github/actions/install-briefcase/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: "Override value for github.ref_name; only for testing."
     required: false
 
+secrets:
+  github-token:
+    required: true
+
 outputs:
   installed-version:
     value: ${{ steps.install.outputs.version }}
@@ -40,7 +44,7 @@ runs:
         PR_BODY="${{ inputs.testing-pr-body }}"
         if [ -z "${PR_BODY}" ]; then
           API_URL="${{ github.api_url }}/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}"
-          API_RESPONSE=$(curl -s -H "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github+json" "${API_URL}")
+          API_RESPONSE=$(curl -s -H "authorization: Bearer ${{ secrets.github-token }}" -H "Accept: application/vnd.github+json" "${API_URL}")
           echo "::group::GitHub API Response"
           echo "${API_RESPONSE}"
           echo "::endgroup::"

--- a/.github/actions/install-briefcase/action.yml
+++ b/.github/actions/install-briefcase/action.yml
@@ -23,9 +23,8 @@ inputs:
   testing-ref-name:
     description: "Override value for github.ref_name; only for testing."
     required: false
-
-secrets:
   github-token:
+    description: "A Github access token with read permissions for pull requests"
     required: true
 
 outputs:

--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -5,6 +5,9 @@ name: Build App
 # If a platform and format are not specified, then an app is built for each platform and format supported on the OS.
 #######
 
+permissions:
+  pull-requests: read
+
 on:
   workflow_call:
     inputs:
@@ -124,6 +127,7 @@ jobs:
     - name: Install Briefcase
       if: ${{ !endsWith(inputs.repository, 'briefcase') }}
       uses: ./beeware-.github/.github/actions/install-briefcase
+      secrets: inherit
 
     - name: Create Briefcase project
       # Don't run for template repos since they already contain a created app.

--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -5,9 +5,6 @@ name: Build App
 # If a platform and format are not specified, then an app is built for each platform and format supported on the OS.
 #######
 
-permissions:
-  pull-requests: read
-
 on:
   workflow_call:
     inputs:
@@ -55,9 +52,6 @@ jobs:
   verify-app:
     name: Verify App Build
     runs-on: ${{ inputs.runner-os }}
-    secrets:
-      github-token: ${{ secrets.github-token }}
-
     steps:
 
     - name: Checkout ${{ inputs.repository }}
@@ -133,6 +127,8 @@ jobs:
     - name: Install Briefcase
       if: ${{ !endsWith(inputs.repository, 'briefcase') }}
       uses: ./beeware-.github/.github/actions/install-briefcase
+      with:
+        github-token: ${{ secrets.github-token }}
 
     - name: Create Briefcase project
       # Don't run for template repos since they already contain a created app.

--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -43,6 +43,9 @@ on:
         description: "Path to use for --template for `briefcase new` to create app."
         default: ""
         type: string
+    secrets:
+      github-token:
+        required: true
 
 defaults:
   run:
@@ -127,7 +130,8 @@ jobs:
     - name: Install Briefcase
       if: ${{ !endsWith(inputs.repository, 'briefcase') }}
       uses: ./beeware-.github/.github/actions/install-briefcase
-      secrets: inherit
+      secrets:
+        github-token: ${{ secrets.github-token }}
 
     - name: Create Briefcase project
       # Don't run for template repos since they already contain a created app.

--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -55,6 +55,9 @@ jobs:
   verify-app:
     name: Verify App Build
     runs-on: ${{ inputs.runner-os }}
+    secrets:
+      github-token: ${{ secrets.github-token }}
+
     steps:
 
     - name: Checkout ${{ inputs.repository }}
@@ -130,8 +133,6 @@ jobs:
     - name: Install Briefcase
       if: ${{ !endsWith(inputs.repository, 'briefcase') }}
       uses: ./beeware-.github/.github/actions/install-briefcase
-      secrets:
-        github-token: ${{ secrets.github-token }}
 
     - name: Create Briefcase project
       # Don't run for template repos since they already contain a created app.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
         testing-trigger-ref: ${{ matrix.testing-trigger-ref }}
         testing-pr-ref: ${{ matrix.testing-pr-ref }}
         testing-ref-name: ${{ matrix.testing-ref-name }}
+      secrets: inherit
 
     - name: Test Briefcase @ ${{ matrix.test-case }}
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
     needs: pre-commit
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -107,8 +109,6 @@ jobs:
         testing-trigger-ref: ${{ matrix.testing-trigger-ref }}
         testing-pr-ref: ${{ matrix.testing-pr-ref }}
         testing-ref-name: ${{ matrix.testing-ref-name }}
-      secrets:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Test Briefcase @ ${{ matrix.test-case }}
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  pull-requests: read
+
 jobs:
   pre-commit:
     name: Pre-commit checks
@@ -26,8 +29,6 @@ jobs:
     needs: pre-commit
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    secrets:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -109,6 +110,7 @@ jobs:
         testing-trigger-ref: ${{ matrix.testing-trigger-ref }}
         testing-pr-ref: ${{ matrix.testing-pr-ref }}
         testing-ref-name: ${{ matrix.testing-ref-name }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Test Briefcase @ ${{ matrix.test-case }}
       run: |
@@ -204,6 +206,8 @@ jobs:
       repository: beeware/briefcase
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -220,6 +224,8 @@ jobs:
       briefcase-template-source: "../../"
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -237,6 +243,8 @@ jobs:
       target-platform: android
       target-format: gradle
       framework: toga
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -253,6 +261,8 @@ jobs:
       target-platform: iOS
       target-format: xcode
       framework: toga
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   test-verify-apps-appimage-templates:
     name: Test Verify AppImage App
@@ -265,6 +275,8 @@ jobs:
       target-platform: linux
       target-format: appimage
       framework: ${{ matrix.framework }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -281,6 +293,8 @@ jobs:
       target-platform: linux
       target-format: flatpak
       framework: toga
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   test-verify-apps-macOS-templates:
     name: Test Verify macOS App
@@ -293,6 +307,8 @@ jobs:
       target-platform: macOS
       target-format: ${{ matrix.format }}
       framework: ${{ matrix.framework }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -310,6 +326,8 @@ jobs:
       target-platform: web
       target-format: static
       framework: toga
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   test-verify-apps-windows-templates:
     name: Test Verify Windows App
@@ -323,6 +341,8 @@ jobs:
       target-platform: windows
       target-format: ${{ matrix.format }}
       framework: ${{ matrix.framework }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,8 @@ jobs:
         testing-trigger-ref: ${{ matrix.testing-trigger-ref }}
         testing-pr-ref: ${{ matrix.testing-pr-ref }}
         testing-ref-name: ${{ matrix.testing-ref-name }}
-      secrets: inherit
+      secrets:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Test Briefcase @ ${{ matrix.test-case }}
       run: |

--- a/.github/workflows/dependabot-changenote.yml
+++ b/.github/workflows/dependabot-changenote.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           # Fetch PR number for commit from Github API
           API_URL="${{ github.api_url }}/repos/${{ github.repository }}/commits/${{ github.event.head_commit.id }}/pulls"
-          PR_NUM=$(curl -s -H "Accept: application/vnd.github+json" "${API_URL}" | jq -r '.[].number')
+          PR_NUM=$(curl -s -H "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github+json" "${API_URL}" | jq -r '.[].number')
 
           # Create change note from first line of dependabot commit
           NEWS=$(printf "%s" "${{ github.event.head_commit.message }}" | head -n1 | sed -e 's/Bump/Updated/')

--- a/.github/workflows/dependabot-changenote.yml
+++ b/.github/workflows/dependabot-changenote.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           # Fetch PR number for commit from Github API
           API_URL="${{ github.api_url }}/repos/${{ github.repository }}/commits/${{ github.event.head_commit.id }}/pulls"
-          PR_NUM=$(curl -s -H "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github+json" "${API_URL}" | jq -r '.[].number')
+          PR_NUM=$(curl -s -H "authorization: Bearer ${{ secrets.BRUTUS_PAT_TOKEN }}" -H "Accept: application/vnd.github+json" "${API_URL}" | jq -r '.[].number')
 
           # Create change note from first line of dependabot commit
           NEWS=$(printf "%s" "${{ github.event.head_commit.message }}" | head -n1 | sed -e 's/Bump/Updated/')


### PR DESCRIPTION
We've started hitting the API rate limit when querying the Github API. e.g.,

https://github.com/beeware/briefcase-web-static-template/actions/runs/4273741637/jobs/7496132787

We should be able to get a vastly increased rate limit by using authenticated API access.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
