### PR TITLE
Use Authenticated GitHub API calls via `gh` and `github.token`

### DIFF
--- a/.github/actions/install-briefcase/action.yml
+++ b/.github/actions/install-briefcase/action.yml
@@ -41,7 +41,7 @@ runs:
         # Source version from Body of PR
         PR_BODY="${{ inputs.testing-pr-body }}"
         if [ -z "${PR_BODY}" ]; then
-          PR_BODY=$(gh api repos/{owner}/{repo}/pulls/${{ github.event.pull_request.number }} --jq '.body')
+          PR_BODY=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} --jq '.body')
           printf "::group::Retrieved PR Body\n${PR_BODY}\n::endgroup::\n"
         fi
         BRIEFCASE_REPO=$(printf "%s" "${PR_BODY}" | perl -wlne '/BRIEFCASE[-_]*REPO:\s*\K\S+/i and print $&')

--- a/.github/actions/install-briefcase/action.yml
+++ b/.github/actions/install-briefcase/action.yml
@@ -34,17 +34,15 @@ runs:
   steps:
     - name: Use Specified Briefcase Version
       id: briefcase-override
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
       shell: bash
       run: |
         # Source version from Body of PR
         PR_BODY="${{ inputs.testing-pr-body }}"
         if [ -z "${PR_BODY}" ]; then
-          API_URL="${{ github.api_url }}/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}"
-          API_RESPONSE=$(curl -s -H "Accept: application/vnd.github+json" "${API_URL}")
-          echo "::group::GitHub API Response"
-          echo "${API_RESPONSE}"
-          echo "::endgroup::"
-          PR_BODY=$(printf "%s" "${API_RESPONSE}" | jq -r '.body')
+          PR_BODY=$(gh api repos/{owner}/{repo}/pulls/${{ github.event.pull_request.number }} --jq '.body')
+          printf "::group::Retrieved PR Body\n${PR_BODY}\n::endgroup::\n"
         fi
         BRIEFCASE_REPO=$(printf "%s" "${PR_BODY}" | perl -wlne '/BRIEFCASE[-_]*REPO:\s*\K\S+/i and print $&')
         BRIEFCASE_REF=$(printf "%s" "${PR_BODY}" | perl -wlne '/BRIEFCASE[-_]*REF:\s*\K\S+/i and print $&')

--- a/.github/workflows/dependabot-changenote.yml
+++ b/.github/workflows/dependabot-changenote.yml
@@ -26,17 +26,19 @@ jobs:
           git config --local user.name "Dependabot[bot]"
 
       - name: Commit Change Note
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          # Fetch PR number for commit from Github API
-          API_URL="${{ github.api_url }}/repos/${{ github.repository }}/commits/${{ github.event.head_commit.id }}/pulls"
-          PR_NUM=$(curl -s -H "Accept: application/vnd.github+json" "${API_URL}" | jq -r '.[].number')
+          # Retrieve PR number from GitHub API
+          PR_NUM=$(gh api repos/{owner}/{repo}/commits/${{ github.event.head_commit.id }}/pulls --jq '.[].number')
+          CHANGENOTE_FILEPATH="./changes/${PR_NUM}.misc.rst"
 
           # Create change note from first line of dependabot commit
           NEWS=$(printf "%s" "${{ github.event.head_commit.message }}" | head -n1 | sed -e 's/Bump/Updated/')
-          printf "%s.\n" "${NEWS}" > "./changes/${PR_NUM}.misc.rst"
+          printf "%s.\n" "${NEWS}" > "${CHANGENOTE_FILEPATH}"
 
           # Commit the change note
-          git add "./changes/${PR_NUM}.misc.rst"
+          git add "${CHANGENOTE_FILEPATH}"
           # "dependabot skip" tells Dependabot to continue rebasing this branch despite foreign commits
           git commit -m "Add changenote. [dependabot skip]"
 


### PR DESCRIPTION
## Summary
This is an alternative implementation for #18 to avoid API calls being rate limited.

As we've discovered, GitHub aggressively rate limits unauthenticated API calls. To authenticate, the GitHub API needs a valid token in the HTTP.

## Changes
- Use GitHub's `gh` tool to talk to the API
  - This is more robust than `curl`ing and I probably should have used it from the get go.
- Use the implicitly provided GitHub token for the workflow run
  - For each workflow run, GitHub generates a token that's valid for the length of the run.
  - The token is exposed via the `github` context as `github.token`.
  - When a workflow invokes an action or workflow, the `github` context is [implicitly passed](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) to the called workflow.
  - The `gh` tool will use the `GITHUB_TOKEN` env var to authenticate any API calls.
  - Permissions for `github.token`
    - The [permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) for this auto-generated token can be controlled at many levels from the Organization down to inside the yaml.
    - This includes a `read` permission for `pull_request`.
    - However, I can only reason that this permission is necessary for private repos. I mean, the API endpoints for pull requests in public repos are available to the whole world via unauthenticated requests.
    - Therefore, I do not expect calling workflows to need to explicitly set this permission.

## Examples
- Dependabot changenote [workflow run](https://github.com/rmartin16/briefcase-windows-app-template-test-1/actions/runs/4305721605/jobs/7508565863)
- PR without Briefcase Repo or Ref [workflow run](https://github.com/rmartin16/briefcase-windows-app-template-test-1/actions/runs/4305721734/jobs/7508565763)
- PR with Briefcase Repo or Ref [workflow run](https://github.com/rmartin16/briefcase-windows-app-template-test-1/actions/runs/4305766600/jobs/7508677431)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
