### PR TITLE
Don't try to retrieve the PR number if this run isn't due to a PR.

### DIFF
--- a/.github/actions/install-briefcase/action.yml
+++ b/.github/actions/install-briefcase/action.yml
@@ -38,9 +38,10 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
       shell: bash
       run: |
-        # Source version from Body of PR
+        # Source version from Body of PR (if there is one; if there isn't,
+        # github.event.pull_request.number will be empty)
         PR_BODY="${{ inputs.testing-pr-body }}"
-        if [ -z "${PR_BODY}" ]; then
+        if [ -z "${PR_BODY}" -a "${{ github.event.pull_request.number }}" ]; then
           PR_BODY=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} --jq '.body')
           printf "::group::Retrieved PR Body\n${PR_BODY}\n::endgroup::\n"
         fi

--- a/.github/actions/install-briefcase/action.yml
+++ b/.github/actions/install-briefcase/action.yml
@@ -41,7 +41,7 @@ runs:
         # Source version from Body of PR (if there is one; if there isn't,
         # github.event.pull_request.number will be empty)
         PR_BODY="${{ inputs.testing-pr-body }}"
-        if [ -z "${PR_BODY}" -a "${{ github.event.pull_request.number }}" ]; then
+        if [[ -z "${PR_BODY}" && -n "${{ github.event.pull_request.number }}" ]]; then
           PR_BODY=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} --jq '.body')
           printf "::group::Retrieved PR Body\n${PR_BODY}\n::endgroup::\n"
         fi


### PR DESCRIPTION
#19 worked great in CI, but failed when the PR was merged because it relied on the existence of a PR number during the CI run. 

Side note: This does mean that PRs that pass because of a `B***case-repo:` (redacted so it doesn't catch on *this* pr... 🤦 ) configuration will fail when the PR is merged. I'm not sure there's much we can do about that, though - this is just part of the "chicken and egg" problem.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
