### PR TITLE
Skip RPM build tests for PySide2

### DIFF
--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -217,8 +217,10 @@ jobs:
         briefcase package linux system --target debian:bullseye --adhoc-sign
 
     - name: Build Linux System project (RPM, Dockerized)
+      # fedora:37 ships with Python 3.11 and PySide2 cannot be installed
       if: |
         startsWith(inputs.runner-os, 'ubuntu')
+        && !contains(fromJSON('["PySide2"]'), inputs.framework)
         && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
         && contains(fromJSON('["", "system"]'), inputs.target-format)
       run: |


### PR DESCRIPTION
- `fedora:37` ships with Python 3.11 and PySide2 cannot be installed.

ref: beeware/briefcase-template#59

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
