### PR TITLE
Allow Arch packaging.

### DIFF
--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -238,8 +238,7 @@ jobs:
         cd tests/apps/verify-${{ inputs.framework }}
         briefcase create linux system --target archlinux:latest
         briefcase build linux system --target archlinux:latest
-        # FIXME: Arch packaging not supported (yet!)
-        # briefcase package linux system --target archlinux:latest --adhoc-sign
+        briefcase package linux system --target archlinux:latest --adhoc-sign
 
     - name: Build AppImage project
       if: >


### PR DESCRIPTION
With the addition of Arch packaging support in beeware/briefcase#1143, we can now enable Arch package builds as part of CI configurations. 

Refs beeware/briefcase#1143

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
