### PR TITLE
Quote bash variables with double quotes

### DIFF
--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -45,8 +45,8 @@ jobs:
 
       - name: Configure git
         run: |
-          git config user.email 'brutus@beeware.org'
-          git config user.name 'Brutus (robot)'
+          git config user.email "brutus@beeware.org"
+          git config user.name "Brutus (robot)"
 
       - name: Set up Python
         uses: actions/setup-python@v4.5.0
@@ -70,9 +70,9 @@ jobs:
         id: pr
         run: |
           if [[ $(git status --porcelain) ]]; then
-            echo 'needed=true' >> ${GITHUB_OUTPUT}
+            echo "needed=true" >> ${GITHUB_OUTPUT}
           else
-            echo 'needed=false' >> ${GITHUB_OUTPUT}
+            echo "needed=false" >> ${GITHUB_OUTPUT}
           fi
 
       - name: Create Pull Request
@@ -95,9 +95,9 @@ jobs:
           git fetch origin
           git checkout ${{ env.BRANCH_NAME }}
 
-          FILENAME='${{ env.CHANGENOTE_DIR }}/${{ steps.created-pr.outputs.pull-request-number }}.misc.rst'
-          printf 'Updated ``pre-commit`` hooks to the latest version.\n' > '${FILENAME}'
+          FILENAME="${{ env.CHANGENOTE_DIR }}/${{ steps.created-pr.outputs.pull-request-number }}.misc.rst"
+          printf 'Updated ``pre-commit`` hooks to the latest version.\n' > "${FILENAME}"
 
-          git add '${FILENAME}'
-          git commit -m 'Add changenote.'
+          git add "${FILENAME}"
+          git commit -m "Add changenote."
           git push --set-upstream origin ${{ env.BRANCH_NAME }}


### PR DESCRIPTION
Runs of the `pre-commit-update` workflow failed because I wrapped the bash variable for the filename in single quotes; so all the changenotes were titled `${FILENAME}`....let's use double quotes instead.

Example: https://github.com/beeware/briefcase/pull/1162

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
