### PR TITLE
Introduce workflow to verify ReadTheDocs build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,23 @@ jobs:
     with:
       pre-commit-source: "pre-commit"
 
+  test-docs-build-verify:
+    name: Test Verify Docs Build
+    needs: pre-commit
+    uses: ./.github/workflows/docs-build-verify.yml
+    secrets: inherit
+    with:
+      project-name: ${{ matrix.name }}
+      project-version: ${{ matrix.version }}
+    strategy:
+      matrix:
+        name: [ "briefcase", "toga" ]
+        include:
+        - name: "briefcase"
+          version: "v0.3.13"
+        - name: "toga"
+          version: "v0.3.1"
+
   test-install-briefcase:
     name: Test Install Briefcase
     needs: pre-commit

--- a/.github/workflows/docs-build-verify.yml
+++ b/.github/workflows/docs-build-verify.yml
@@ -1,0 +1,53 @@
+name: Verify ReadTheDocs Build
+
+#######
+# Successfully completes if ReadTheDocs has successfully built docs for a project version.
+# Errors if docs are not successfully built after a finite amount of time.
+#######
+
+on:
+  workflow_call:
+    inputs:
+      project-name:
+        description: "Name of project on ReadTheDocs; e.g. briefcase."
+        required: true
+        type: string
+      project-version:
+        description: "Version of the docs to verify were built; e.g. v0.3.13."
+        required: true
+        type: string
+      timeout:
+        description: "Amount of time to wait for ReadTheDocs to report success; defaults to 10 minutes."
+        default: 10
+        type: number
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  docs:
+    name: Verify RTD Docs
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout }}
+    env:
+      RTD_API_URL: "https://readthedocs.org/api/v3/projects/${{ inputs.project-name }}/versions/${{ inputs.project-version }}/"
+    steps:
+      - name: Verify RTD Built Docs for ${{ inputs.project-version }}
+        run: |
+          echo "Verifying docs for ${{ inputs.project-version }} were successfully built:"
+          while true
+          do
+              RTD_RESPONSE=$(curl -s -H "Authorization: Token ${{ secrets.RTD_API_TOKEN }}" "${RTD_API_URL}")
+              IS_DOCS_BUILT=$(jq .built <<< ${RTD_RESPONSE})
+
+              echo "::group::IS_DOCS_BUILT=${IS_DOCS_BUILT}"
+              jq <<< ${RTD_RESPONSE}
+              echo "::endgroup::"
+
+              if [[ "${IS_DOCS_BUILT}" == "true" ]]; then
+                  exit 0
+              fi
+
+              sleep 5
+          done


### PR DESCRIPTION
## Changes
- Creates a reusable workflow that waits until RTD reports a build for a specific version is complete.
- This is intended to apply a dependency on docs builds for publishing releases.
  - See beeware/briefcase#1182
- The BeeWare organization secret `RTD_API_TOKEN` provides token for HTTP API authorization.

## Notes
- The intended use-case would be running this workflow when the release tag is pushed to the repo.,
- And if this workflow fails, the progression to create a GitHub release and artifacts does not occur.
- Supersedes #29 
  - Created branch directly on `beeware/.github` since secrets cannot be shared across forks.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
