### PR TITLE
Include date in winstore Python cache key to limit cache age

### DIFF
--- a/.github/actions/install-win-store-python/action.yml
+++ b/.github/actions/install-win-store-python/action.yml
@@ -48,11 +48,14 @@ runs:
         echo "scripts-dir=$ScriptsDir" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
         echo "appx-path=$(Join-Path "$env:TEMP" python-${{ inputs.python-version }}.appx)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
 
+        echo "current-year=$(Get-Date -UFormat "%Y")" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+        echo "current-month=$(Get-Date -UFormat "%m")" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+
     - name: Cache Python AppxBundle
       uses: actions/cache@v3.2.3
       with:
         path: ${{ steps.python.outputs.appx-path }}
-        key: python-${{ steps.python.outputs.version }}-appx-bundle
+        key: python-${{ steps.python.outputs.version }}-appx-bundle-${{ steps.python.outputs.current-year }}-${{ steps.python.outputs.current-month }}
 
     - name: Install Windows Store Python ${{ steps.python.outputs.version }}
       shell: powershell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     name: Test Verify Docs Build
     needs: pre-commit
     # inheriting secrets does not work for forked repos
-    if: ${{ github.event.pull_request.head.repo.owner == 'beeware' }}
+    if: ${{ github.event.pull_request.head.repo.owner.login == 'beeware' }}
     uses: ./.github/workflows/docs-build-verify.yml
     secrets: inherit
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
   test-docs-build-verify:
     name: Test Verify Docs Build
     needs: pre-commit
+    # inheriting secrets does not work for forked repos
+    if: ${{ github.event.pull_request.head.repo.owner == 'beeware' }}
     uses: ./.github/workflows/docs-build-verify.yml
     secrets: inherit
     with:


### PR DESCRIPTION
## Changes
- While GitHub will evict caches after not being used for 7 days, the cache will exist in perpetuity as long as it is regularly referenced.
- To ensure the Windows Store Python that's installed stays up to date, the current year and month is added to the cache key so they cache is recreated each month.
- Additionally, since this the first CI run since adding the test for RTD Builds, it is now clear the test will always fail for PRs from forks so I modified the test to only run for branches on this repo.

## Notes
- Caches with the year and date in the name can be seen [here](https://github.com/beeware/.github/actions/caches).
- GitHub does provide an API to delete caches....but it seems especially over-engineered to periodically check the age of these caches and delete them manually.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
