### PR TITLE
Disable PySide2 app build on Arch since using Python 3.11 now

### DIFF
--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -230,8 +230,10 @@ jobs:
         briefcase package linux system --target fedora:37 --adhoc-sign
 
     - name: Build Linux System project (Arch, Dockerized)
+      # arch started shipping Python 3.11 on 3 may 2023 and PySide2 cannot be installed
       if: >
         startsWith(inputs.runner-os, 'ubuntu')
+        && !contains(fromJSON('["PySide2"]'), inputs.framework)
         && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
         && contains(fromJSON('["", "system"]'), inputs.target-format)
       run: |


### PR DESCRIPTION
Arch started installing Python 3.11 so PySide2 can no longer be tested on it.

ex. https://github.com/beeware/briefcase/actions/runs/4877899896/jobs/8703110166

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
