### PR TITLE
Use `FORCE_COLOR` to enable colored output in CI

### DIFF
--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -45,6 +45,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  FORCE_COLOR: "1"
+
 jobs:
   verify-app:
     name: Verify App Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,16 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash
 
-concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: true
+env:
+  FORCE_COLOR: "1"
 
 jobs:
   pre-commit:

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Run pre-commit
         # pre-commit returns non-zero when files are changed and fails the job
         continue-on-error: true
-        run: pre-commit run --all-files --color=always
+        run: pre-commit run --all-files
 
       - name: PR Needed?
         id: pr

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -25,6 +25,7 @@ permissions:
 env:
   BRANCH_NAME: "autoupdates/pre-commit"
   CHANGENOTE_DIR: "./changes"
+  FORCE_COLOR: "1"
 
 defaults:
   run:

--- a/.github/workflows/python-package-create.yml
+++ b/.github/workflows/python-package-create.yml
@@ -36,6 +36,9 @@ on:
         description: "Name of the uploaded artifact; use for artifact retrieval."
         value: ${{ jobs.package.outputs.artifact-name }}
 
+env:
+  FORCE_COLOR: "1"
+
 jobs:
   package:
     name: Create Python Package

--- a/.github/workflows/python-package-create.yml
+++ b/.github/workflows/python-package-create.yml
@@ -71,11 +71,11 @@ jobs:
 
       - name: Build wheels
         if: inputs.build-subdirectory == ''
-        run: tox --colored yes -e package
+        run: tox -e package
 
       - name: Build wheels from subdirectory
         if: inputs.build-subdirectory != ''
-        run: tox --colored yes -e package -- ${{ inputs.build-subdirectory }}
+        run: tox -e package -- ${{ inputs.build-subdirectory }}
 
       - name: Upload Package
         uses: actions/upload-artifact@v3.1.2

--- a/.github/workflows/towncrier-run.yml
+++ b/.github/workflows/towncrier-run.yml
@@ -64,4 +64,4 @@ jobs:
       run: python -m pip install ${{ inputs.tox-source }}
 
     - name: Run towncrier check
-      run: tox --colored yes -e towncrier-check
+      run: tox -e towncrier-check

--- a/.github/workflows/towncrier-run.yml
+++ b/.github/workflows/towncrier-run.yml
@@ -28,6 +28,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  FORCE_COLOR: "1"
+
 jobs:
   towncrier:
     name: Towncrier Checks


### PR DESCRIPTION
## Changes
- Reverted 36cbe2fd1927c4cb2304f08b0622572077a6a2e4 in favor of setting `FORCE_COLOR=1` to activate color output in CI

## Notes
- While there isn't a standard for enabling/forcing colored output, there is some agreement about using `FORCE_COLOR`
  - For context, this all revolves around the shells in GitHub runner not [using a tty](https://github.com/actions/runner/issues/241)
  - At any rate, Python, at least, seems to have aggregated around `FORCE_COLOR` for the most part:
    - `pytest` had been using `PY_COLOR` env var for a while...but it never really caught on
    - Initially, Will was [against](https://github.com/Textualize/rich/issues/343) this in Rich; he was eventually [convinced](https://github.com/pypa/pip/issues/10909) that [respecting](https://github.com/Textualize/rich/pull/2449) `FORCE_COLOR` made sense
    - `tox` has [supported](https://github.com/tox-dev/tox/pull/1630) it since v4
    - `pytest` has [supported](https://github.com/pytest-dev/pytest/pull/7466) it since v6
    - While `pip` is supposed to respect `FORCE_COLOR`, I don't see it working in CI...
- So, I think this is a better approach than trying to activate it for each tool
  - Perhaps unfortunately, it does require setting the env var in each workflow
  - I couldn't find a way to configure GitHub to inject an env var in to every workflow run...

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
