### PR TITLE
Clear the `JAVA_HOME*` and `ANDROID*` environment variables prior to building Android app

### DIFF
--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -277,8 +277,14 @@ jobs:
         && contains(fromJSON('["", "Gradle"]'), inputs.target-format)
         && startsWith(inputs.framework, 'toga')
       run: |
+        # force Briefcase to use its own installs of JDK and Android SDK
+        # clear all env vars starting with "JAVA_HOME" or "ANDROID"
+        unset "${!JAVA_HOME@}"
+        unset "${!ANDROID@}"
+
         cd tests/apps/verify-${{ inputs.framework }}
-        briefcase create android gradle
+        # pipe "yes" to accept Android SDK licenses
+        (2>/dev/null yes || true) | briefcase create android gradle
         briefcase build android gradle
         briefcase package android gradle --adhoc-sign
 


### PR DESCRIPTION
## Changes
- GitHub runners bring along their own JDK and Android SDK
  - `JAVA_HOME=/usr/lib/jvm/temurin-11-jdk-amd64`
  - `JAVA_HOME_11_X64=/usr/lib/jvm/temurin-11-jdk-amd64`
  - `JAVA_HOME_8_X64=/usr/lib/jvm/temurin-8-jdk-amd64`
  - `JAVA_HOME_17_X64=/usr/lib/jvm/temurin-17-jdk-amd64`
  - `ANDROID_SDK_ROOT=/usr/local/lib/android/sdk`
  - `ANDROID_HOME=/usr/local/lib/android/sdk`
  - `ANDROID_NDK=/usr/local/lib/android/sdk/ndk/25.2.9519653`
  - `ANDROID_NDK_LATEST_HOME=/usr/local/lib/android/sdk/ndk/25.2.9519653`
  - `ANDROID_NDK_HOME=/usr/local/lib/android/sdk/ndk/25.2.9519653`
- NOTE: Not all GitHub runners use the same Android SDK and JDK; for instance, Ubuntu-22.04 is exposing JDK 11 while Windows Server 2022 and macOS 12.6.5 are exposing JDK 8.
- This PR clears all environment variables that start with `JAVA_HOME` and `ANDROID` so Briefcase will install and use its own Android SDK and JDK for testing.
  - The fact that all these environment variables are affecting the behavior of Briefcase and its underlying tools so much suggests that we may be better off running these tests in isolated environments like `tox` does
- Tested these changes with JDK 17: https://github.com/beeware/briefcase-android-gradle-template/actions/runs/5165357682

## Notes
- ~~A question hit me in the shower: "what will happen to people with `JAVA_HOME` already set to JDK 11?"~~
- ~~Well....turns out we've already been testing that all along since our CI has been using GitHub's JDK 11 install.~~

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
