### PR TITLE
Push the pre-commit update changenote to the right branch

### DIFF
--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -115,6 +115,8 @@ jobs:
       - name: Add changenote
         if: (inputs.create-changenote == true) && (steps.created-pr.outputs.pull-request-number != '')
         run: |
+          BRANCH_NAME="${{ env.BRANCH_PREFIX }}/${{ steps.pr.outputs.hook-name }}"
+
           git fetch origin
           git checkout ${{ env.BRANCH_NAME }}
 


### PR DESCRIPTION
## Changes
- After #39, updates to pre-commit hooks are made in their own branch and PR....but the changenote is being pushed to the default branch for the repo....
- This ensures the changenote is pushed to the branch created for the PR for the updated pre-commit hook
- Issue example: https://github.com/beeware/briefcase/actions/runs/5170991108/jobs/9314256640

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
