### PR TITLE
Include version bump info in PRs for pre-commit hook updates

### DIFF
--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -78,8 +78,10 @@ jobs:
         run: python -m pip install ${{ inputs.pre-commit-source || 'pre-commit' }}
 
       - name: Update pre-commit hooks
+        id: update
         run: |
-          pre-commit autoupdate --repo ${{ matrix.hook-repo }}
+          pre-commit autoupdate --repo ${{ matrix.hook-repo }} | tee update.log
+          echo "vers-bump-str=$(grep -ohE '([^ ]+ -> [^ ]+)' update.log | sed 's/->/to/')" >> ${GITHUB_OUTPUT}
           pre-commit install-hooks
 
       - name: Run pre-commit
@@ -104,12 +106,12 @@ jobs:
         uses: peter-evans/create-pull-request@v5.0.1
         with:
           token: ${{ secrets.BRUTUS_PAT_TOKEN }}
-          title: "Bump pre-commit hook for ${{ steps.pr.outputs.hook-name }}"
+          title: "Bump ${{ steps.pr.outputs.hook-name }} from ${{ steps.update.outputs.vers-bump-str }}"
           branch: "${{ env.BRANCH_PREFIX }}/${{ steps.pr.outputs.hook-name }}"
-          commit-message: "Bumped pre-commit hook for ${{ steps.pr.outputs.hook-name }}"
+          commit-message: "Bump ${{ steps.pr.outputs.hook-name }} from ${{ steps.update.outputs.vers-bump-str }}"
           committer: "Brutus (robot) <brutus@beeware.org>"
           author: "Brutus (robot) <brutus@beeware.org>"
-          body: "Automatically bumped `pre-commit` hook for `${{ steps.pr.outputs.hook-name }}` and ran the update against the repo."
+          body: "Bumps `pre-commit` hook for `${{ steps.pr.outputs.hook-name }}` from ${{ steps.update.outputs.vers-bump-str }} and ran the update against the repo."
           labels: "dependencies"
 
       - name: Add changenote


### PR DESCRIPTION
## Changes
- In getting one step closer to dependabot, pre-commit hook updates will include version bump info now
- Once this is merged, the `Update pre-commit` workflow could be manually rerun to replace the existing PRs

Version bump example from Briefcase:
```console
❯ pre-commit autoupdate | tee update.log
[https://github.com/pre-commit/pre-commit-hooks] updating v4.3.0 -> v4.4.0
[https://github.com/PyCQA/isort] updating 5.11.5 -> 5.12.0
[https://github.com/asottile/pyupgrade] updating v3.5.0 -> v3.6.0
[https://github.com/PyCQA/docformatter] updating v1.7.1 -> v1.7.2
[https://github.com/psf/black] updating 23.1.0 -> 23.3.0
[https://github.com/PyCQA/flake8] updating 5.0.4 -> 6.0.0

❯ grep -ohE '([^ ]+ -> [^ ]+)' update.log  | sed 's/->/to/'
v4.3.0 to v4.4.0
5.11.5 to 5.12.0
v3.5.0 to v3.6.0
v1.7.1 to v1.7.2
23.1.0 to 23.3.0
5.0.4 to 6.0.0
```

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
