### PR TITLE
Remove AppImage from the CI testing matrix.

### DIFF
--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -245,16 +245,28 @@ jobs:
         briefcase build linux system --target archlinux:latest
         briefcase package linux system --target archlinux:latest --adhoc-sign
 
-    - name: Build AppImage project
-      if: >
-        startsWith(inputs.runner-os, 'ubuntu')
-        && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
-        && contains(fromJSON('["", "AppImage"]'), inputs.target-format)
-      run: |
-        cd tests/apps/verify-${{ inputs.framework }}
-        briefcase create linux AppImage
-        briefcase build linux AppImage
-        briefcase package linux AppImage --adhoc-sign
+    # 2023-09-11 AppImage dropped to "best effort" support.
+    #
+    # AppImage builds are the slowest, because they're incompatible with binary wheels;
+    # and installing Linux GUI toolkits (which are on a constant "install the latest"
+    # push) is fundamentally incompatible with using an old base image. As of today,
+    # it's impossible to install Toga on *any* manylinux image (
+    # https://gitlab.gnome.org/GNOME/pygobject/-/issues/590); PySide2 can't be
+    # installed on any *supported* manylinux image, and PySide6 only works on 2_28.
+    # Even when the install *does* work, there are so many incompatibility and
+    # binary dependency issues that it's just not worth the oxygen to keep this thing
+    # alive.
+    #
+    # - name: Build AppImage project
+    #   if: >
+    #     startsWith(inputs.runner-os, 'ubuntu')
+    #     && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
+    #     && contains(fromJSON('["", "AppImage"]'), inputs.target-format)
+    #   run: |
+    #     cd tests/apps/verify-${{ inputs.framework }}
+    #     briefcase create linux AppImage
+    #     briefcase build linux AppImage
+    #     briefcase package linux AppImage --adhoc-sign
 
     - name: Build Flatpak project
       if: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,21 +292,21 @@ jobs:
       matrix:
         framework: [ "toga", "ppb", "pyside2" ]
 
-  test-verify-apps-appimage-templates:
-    name: Test Verify AppImage App
-    needs: pre-commit
-    uses: ./.github/workflows/app-build-verify.yml
-    with:
-      python-version: "3.9"
-      repository: beeware/briefcase-linux-appimage-template
-      runner-os: ubuntu-latest
-      target-platform: linux
-      target-format: appimage
-      framework: ${{ matrix.framework }}
-    strategy:
-      fail-fast: false
-      matrix:
-        framework: [ "toga", "ppb" ]
+  # test-verify-apps-appimage-templates:
+  #   name: Test Verify AppImage App
+  #   needs: pre-commit
+  #   uses: ./.github/workflows/app-build-verify.yml
+  #   with:
+  #     python-version: "3.9"
+  #     repository: beeware/briefcase-linux-appimage-template
+  #     runner-os: ubuntu-latest
+  #     target-platform: linux
+  #     target-format: appimage
+  #     framework: ${{ matrix.framework }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       framework: [ "toga", "ppb" ]
 
   test-verify-apps-flatpak-templates:
     name: Test Verify Flatpak App


### PR DESCRIPTION
AppImage builds are the slowest, because they're incompatible with binary wheels; and installing Linux GUI toolkits (which are on a constant "install the latest" push) is fundamentally incompatible with using an old base image. 

As of today, [it's impossible to install Toga on *any* manylinux image](https://gitlab.gnome.org/GNOME/pygobject/-/issues/590); PySide2 can't be installed on any *supported* manylinux image, and PySide6 only works on 2_28. Even when the install *does* work, there are so many incompatibility and binary dependency issues that it's just not worth the oxygen to keep AppImage alive.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
