### PR TITLE
Use lowercase "dependabot" name for mocked Dependabot github commits

### DIFF
--- a/.github/workflows/dependabot-changenote.yml
+++ b/.github/workflows/dependabot-changenote.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Configure git
         run: |
           git config --local user.email "$(git log --pretty='%ae' -1)"
-          git config --local user.name "Dependabot[bot]"
+          git config --local user.name "dependabot[bot]"
 
       - name: Commit Change Note
         env:


### PR DESCRIPTION
## Changes
- When mocking commits for Dependabot, use "dependabot" as the name for the commit instead of "Dependabot"

For example, here's a recent [PR](https://github.com/beeware/briefcase/pull/1457) from Dependabot:
```
| * f147742e - (2 days ago) Add changenote. [dependabot skip] - Dependabot[bot] (origin/dependabot/pip/sphinx-7.2.6)
| * 63792c1f - (2 days ago) Bump sphinx from 7.2.5 to 7.2.6 - dependabot[bot]
```

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
