### PR TITLE
Add support to test Flatpak with PyGame

### DIFF
--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -273,7 +273,7 @@ jobs:
         startsWith(inputs.runner-os, 'ubuntu')
         && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
         && contains(fromJSON('["", "Flatpak"]'), inputs.target-format)
-        && startsWith(inputs.framework, 'toga')
+        && contains(fromJSON('["Toga", "PyGame"]'), inputs.framework)
       run: |
         sudo apt-get update -y
         sudo apt-get install -y flatpak flatpak-builder

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
     needs: [pre-commit, test-package-python]
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      python-version: "3.9"
+      python-version: "3.11"
       repository: beeware/briefcase
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
@@ -235,7 +235,7 @@ jobs:
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      python-version: "3.9"
+      python-version: "3.11"
       repository: beeware/briefcase-template
       briefcase-template-source: "../../"
       runner-os: ${{ matrix.runner-os }}
@@ -251,7 +251,7 @@ jobs:
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      python-version: "3.9"
+      python-version: "3.11"
       repository: beeware/briefcase-android-gradle-template
       runner-os: ${{ matrix.runner-os }}
       target-platform: android
@@ -267,7 +267,7 @@ jobs:
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      python-version: "3.9"
+      python-version: "3.11"
       repository: beeware/briefcase-iOS-xcode-template
       runner-os: macos-latest
       target-platform: iOS
@@ -297,7 +297,7 @@ jobs:
   #   needs: pre-commit
   #   uses: ./.github/workflows/app-build-verify.yml
   #   with:
-  #     python-version: "3.9"
+  #     python-version: "3.11"
   #     repository: beeware/briefcase-linux-appimage-template
   #     runner-os: ubuntu-latest
   #     target-platform: linux
@@ -313,19 +313,23 @@ jobs:
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      python-version: "3.9"
+      python-version: "3.11"
       repository: beeware/briefcase-linux-flatpak-template
       runner-os: ubuntu-latest
       target-platform: linux
       target-format: flatpak
-      framework: toga
+      framework: ${{ matrix.framework }}
+    strategy:
+      fail-fast: false
+      matrix:
+        framework: [ "toga", "pygame" ]
 
   test-verify-apps-macOS-templates:
     name: Test Verify macOS App
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      python-version: "3.9"
+      python-version: "3.11"
       repository: beeware/briefcase-macos-${{ matrix.format }}-template
       runner-os: macos-latest
       target-platform: macOS
@@ -342,7 +346,7 @@ jobs:
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      python-version: "3.9"
+      python-version: "3.11"
       repository: beeware/briefcase-web-static-template
       runner-os: ubuntu-latest
       target-platform: web
@@ -354,7 +358,7 @@ jobs:
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      python-version: "3.9"
+      python-version: "3.11"
       python-source: ${{ matrix.python-source }}
       repository: beeware/briefcase-windows-${{ matrix.format }}-template
       runner-os: windows-latest


### PR DESCRIPTION
Previously, the app verification job for Flatpak would only run for Toga; this allows it to run for PyGame as well.

Alternatively, to avoid this in the future, it may be better to remove this check against the "framework" altogether and instead require the repo running the job to exclude invalid frameworks.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
