### PR TITLE
Restore CI for AppImage build configurations.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,21 +292,17 @@ jobs:
       matrix:
         framework: [ "toga", "ppb", "pyside2" ]
 
-  # test-verify-apps-appimage-templates:
-  #   name: Test Verify AppImage App
-  #   needs: pre-commit
-  #   uses: ./.github/workflows/app-build-verify.yml
-  #   with:
-  #     python-version: "3.11"
-  #     repository: beeware/briefcase-linux-appimage-template
-  #     runner-os: ubuntu-latest
-  #     target-platform: linux
-  #     target-format: appimage
-  #     framework: ${{ matrix.framework }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       framework: [ "toga", "ppb" ]
+  test-verify-apps-appimage-templates:
+    name: Test Verify AppImage App
+    needs: pre-commit
+    uses: ./.github/workflows/app-build-verify.yml
+    with:
+      python-version: "3.11"
+      repository: beeware/briefcase-linux-appimage-template
+      runner-os: ubuntu-latest
+      target-platform: linux
+      target-format: appimage
+      framework: toga
 
   test-verify-apps-flatpak-templates:
     name: Test Verify Flatpak App


### PR DESCRIPTION
#58 restored AppImage builds when AppImage is explicitly requested. However, it wasn't possible to restore CI because of a chicken-and-egg problem with the AppImage template used during testing. 

The template has now been updated (beeware/briefcase-linux-appimage-template#39), so we can now re-enable CI.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
