### PR TITLE
Use format string `%s` when printing `PR_BODY` with `printf`

### DIFF
--- a/.github/actions/install-briefcase/action.yml
+++ b/.github/actions/install-briefcase/action.yml
@@ -43,8 +43,9 @@ runs:
         PR_BODY="${{ inputs.testing-pr-body }}"
         if [[ -z "${PR_BODY}" && -n "${{ github.event.pull_request.number }}" ]]; then
           PR_BODY=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} --jq '.body')
-          printf "::group::Retrieved PR Body\n${PR_BODY}\n::endgroup::\n"
         fi
+        printf "::group::Retrieved PR Body\n%s\n::endgroup::\n" "${PR_BODY}"
+
         BRIEFCASE_REPO=$(printf "%s" "${PR_BODY}" | perl -wlne '/BRIEFCASE[-_]*REPO:\s*\K\S+/i and print $&')
         BRIEFCASE_REF=$(printf "%s" "${PR_BODY}" | perl -wlne '/BRIEFCASE[-_]*REF:\s*\K\S+/i and print $&')
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,10 @@ jobs:
           expected: "main"
         # Test PR body override
         - test-case: "PR Repo & Ref"
-          testing-pr-body: "sadf asdf BRIEFCASE_REPO: https://github.com/freakboy3742/briefcase.git xcvbwer BRIEFCASE_REF: 3470d95 xczvb"
+          testing-pr-body: "sadf asdf BRIEFCASE_REPO: https://github.com/freakboy3742/briefcase.git xcvbwer BRIEFCASE_REF: 3470d95 xczvb https://example.com/asdf?q=repo%3Aindygreg%2"
           expected: "3470d95"
         - test-case: "PR Repo & Ref (irregular)"
-          testing-pr-body: "sadf asdf BrIeFcAsE__REpo: https://github.com/freakboy3742/briefcase.git xcvbwer BRIEFcaseREF:3470d95 xczvb"
+          testing-pr-body: "sadf asdf BrIeFcAsE__REpo: https://github.com/freakboy3742/briefcase.git xcvbwer BRIEFcaseREF:3470d95 xczvb https://example.com/asdf?q=repo%3Aindygreg%2"
           expected: "3470d95"
         - test-case: "PR Ref"
           testing-pr-body: "sadf asdf BRIEFcaseREF: v0.3.12"


### PR DESCRIPTION
RE: https://github.com/beeware/briefcase-linux-flatpak-template/pull/26#issuecomment-1780150793

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
