### PR TITLE
Drop an informative error message for towncrier failures

### DIFF
--- a/.github/workflows/pre-commit-run.yml
+++ b/.github/workflows/pre-commit-run.yml
@@ -78,7 +78,7 @@ jobs:
         echo '::error:: '
         echo '::error::Visit the docs below to configure pre-commit in your dev environment:'
         echo '::error:: '
-        echo '::error::    https://beeware.org/contributing/how/process/'
+        echo '::error::    https://beeware.org/contributing/how/process#code-style'
         echo '::error:: '
         echo '::error::*************************************************************************'
         exit 1

--- a/.github/workflows/pre-commit-run.yml
+++ b/.github/workflows/pre-commit-run.yml
@@ -63,4 +63,22 @@ jobs:
       run: python -m pip install ${{ inputs.pre-commit-source }}
 
     - name: Run pre-commit
+      id: pre-commit
       run: pre-commit run --show-diff-on-failure --color=always --all-files
+
+    - name: Pre-commit Resolution Instructions
+      if: always() && steps.pre-commit.outcome == 'failure'
+      run: |
+        echo
+        echo '::error::*************************************************************************'
+        echo '::error::** Pre-commit checks failed                                            **'
+        echo '::error::*************************************************************************'
+        echo '::error:: '
+        echo '::error::The Pre-commit checks found issues with the changes in this PR.'
+        echo '::error:: '
+        echo '::error::Visit the docs below to configure pre-commit in your dev environment:'
+        echo '::error:: '
+        echo '::error::    https://beeware.org/contributing/how/process/'
+        echo '::error:: '
+        echo '::error::*************************************************************************'
+        exit 1

--- a/.github/workflows/towncrier-run.yml
+++ b/.github/workflows/towncrier-run.yml
@@ -67,4 +67,22 @@ jobs:
       run: python -m pip install ${{ inputs.tox-source }}
 
     - name: Run towncrier check
+      id: tox
       run: tox -e towncrier-check
+
+    - name: Towncrier Check Resolution Instructions
+      if: always() && steps.tox.outcome == 'failure'
+      run: |
+        echo
+        echo '::error::*************************************************************************'
+        echo '::error::** Towncrier check failed for missing change note                      **'
+        echo '::error::*************************************************************************'
+        echo '::error:: '
+        echo '::error::A change note for the PR is missing from the `changes` directory.'
+        echo '::error:: '
+        echo '::error::Visit the docs below to learn how to add a change note:'
+        echo '::error:: '
+        echo '::error::    https://beeware.org/contributing/how/process/'
+        echo '::error:: '
+        echo '::error::*************************************************************************'
+        exit 1

--- a/.github/workflows/towncrier-run.yml
+++ b/.github/workflows/towncrier-run.yml
@@ -82,7 +82,7 @@ jobs:
         echo '::error:: '
         echo '::error::Visit the docs below to learn how to add a change note:'
         echo '::error:: '
-        echo '::error::    https://beeware.org/contributing/how/process/'
+        echo '::error::    https://beeware.org/contributing/how/process#change-notes'
         echo '::error:: '
         echo '::error::*************************************************************************'
         exit 1


### PR DESCRIPTION
## Changes
- First time contributors are often left adrift by the towncrier check failure in CI...so, this adds a more informative error message to help them resolve the issue without intervention.
- A similar error message was added for `pre-commit` failures as well.
- Example towncrier failure: https://github.com/beeware/briefcase/actions/runs/7681919133/job/20935600038?pr=1619
- Example pre-commit failure: https://github.com/beeware/briefcase/actions/runs/7681919133/job/20935600087?pr=1619
- Example success: https://github.com/beeware/briefcase/actions/runs/7681926420/job/20935616841?pr=1619

## Notes
- The links above are the same as the "Details" link in the PR Checks box:
![image](https://github.com/beeware/.github/assets/387848/2c366ced-fc5d-46c3-bcb1-fb2a3a793059)
- Another idea I had was trying to push a post to the PR with basically the same information....but that's definitely non-trivial and could result in a lot of duplicate posts if they weren't tracked somehow

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
