### PR TITLE
Support template branch input `app-build-verify` workflow

### DIFF
--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -36,6 +36,10 @@ on:
         description: "Path to use for --template for `briefcase new` to create app."
         default: ""
         type: string
+      briefcase-template-branch:
+        description: "Git branch to use for --template-branch for `briefcase new` to create app."
+        default: ""
+        type: string
 
 defaults:
   run:
@@ -130,8 +134,11 @@ jobs:
         if [[ "${{ inputs.briefcase-template-source }}" != "" ]]; then
           TEMPLATE=$(printf -- "--template %q" "${{ inputs.briefcase-template-source }}")
         fi
+        if [[ "${{ inputs.briefcase-template-branch }}" != "" ]]; then
+          TEMPLATE_BRANCH=$(printf -- "--template-branch %q" "${{ inputs.briefcase-template-branch }}")
+        fi
         cd tests/apps
-        cat verify-${{ inputs.framework }}.config | briefcase new ${TEMPLATE}
+        cat verify-${{ inputs.framework }}.config | briefcase new ${TEMPLATE} ${TEMPLATE_BRANCH}
 
     # In the steps below, using the builtin functions for comparison (instead of ==)
     # allows for case-insensitivity to the inputs for the workflow.


### PR DESCRIPTION
## Changes
- The `app-build-verify` workflow currently supports an input for `--template` for `briefcase new`
- This adds the ability to specify `--template-branch` as well

## Notes
- Can be merged independently of the GUI framework plugin support
- Currently using for testing https://github.com/beeware/briefcase/pull/1524

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
