### PR TITLE
Fallback to GitHub Python if Windows store Python download fails

### DIFF
--- a/.github/actions/install-win-store-python/action.yml
+++ b/.github/actions/install-win-store-python/action.yml
@@ -7,6 +7,11 @@ inputs:
     default: "3.12"  # should default to the latest Python
     required: false
 
+outputs:
+  win-store-install-outcome:
+    description: "Outcome of the Windows Store Python install"
+    value: ${{ steps.install.outcome }}
+
 runs:
   using: composite
   steps:
@@ -63,21 +68,29 @@ runs:
         key: python-${{ steps.python.outputs.version }}-appx-bundle-${{ steps.python.outputs.current-year }}-${{ steps.python.outputs.current-month }}
 
     - name: Install Windows Store Python ${{ steps.python.outputs.version }}
+      id: install
       shell: powershell
+      # Cloudflare started blocking access to the rg-adguard API...fallback to GitHub Python for now
+      continue-on-error: true
       run: |
         if (-not (Test-Path -Path "${{ steps.python.outputs.appx-path }}" -PathType Leaf)) {
           # The Appx download URL must be resolved each time since the URL expires after a few hours
           echo "Downloading Python ${{ steps.python.outputs.version }}..."
-          $WebResponse = Invoke-WebRequest -UseBasicParsing -Method 'POST' -Uri 'https://store.rg-adguard.net/api/GetFiles' -Body "type=url&url=${{ steps.python.outputs.store-url }}&ring=Retail" -ContentType 'application/x-www-form-urlencoded'
-          $DownloadURL = ($WebResponse.Links | where {$_ -like '*.msix*'} | where {$_ -like '*_neutral_*' -or $_ -like "*_"+$env:PROCESSOR_ARCHITECTURE.Replace("AMD","X").Replace("IA","X")+"_*"} | Select-String -Pattern '(?<=a href=").+(?=" r)').matches.value
+          try {
+            $WebResponse = Invoke-WebRequest -UseBasicParsing -Method 'POST' -Uri 'https://store.rg-adguard.net/api/GetFiles' -Body "type=url&url=${{ steps.python.outputs.store-url }}&ring=Retail" -ContentType 'application/x-www-form-urlencoded'
+            $DownloadURL = ($WebResponse.Links | where {$_ -like '*.msix*'} | where {$_ -like '*_neutral_*' -or $_ -like "*_"+$env:PROCESSOR_ARCHITECTURE.Replace("AMD","X").Replace("IA","X")+"_*"} | Select-String -Pattern '(?<=a href=").+(?=" r)').matches.value
 
-          echo "Appx download URL: $DownloadURL"
-          if (($DownloadURL -eq $null) -or ((([uri]$DownloadURL).Host.split('.')[-2..-1] -join '.') -ne "microsoft.com")) {
-            echo $WebResponse
-            echo " >>> Download URL must resolve to microsoft.com. Aborting. <<< "
-            exit 1
+            echo "Appx download URL: $DownloadURL"
+            if (($DownloadURL -eq $null) -or ((([uri]$DownloadURL).Host.split('.')[-2..-1] -join '.') -ne "microsoft.com")) {
+              echo $WebResponse
+              echo " >>> Download URL must resolve to microsoft.com. Aborting. <<< "
+              exit 1
+            }
+            Invoke-WebRequest -Uri $DownloadURL -UseBasicParsing -OutFile ${{ steps.python.outputs.appx-path }}
+          } catch {
+            echo "::error::Downloading Windows Store Python failed; falling back to installing GitHub Python ($_)"
+            throw $_.Exception
           }
-          Invoke-WebRequest -Uri $DownloadURL -UseBasicParsing -OutFile ${{ steps.python.outputs.appx-path }}
         }
 
         echo "Installing Python ${{ steps.python.outputs.version }}..."
@@ -86,3 +99,9 @@ runs:
         echo "Updating `$PATH..."
         echo "${{ steps.python.outputs.exe-dir }}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         echo "${{ steps.python.outputs.scripts-dir }}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+    - name: Python Install Fallback
+      if: always() && steps.install.outcome == 'failure'
+      uses: actions/setup-python@v4.7.1
+      with:
+       python-version: ${{ inputs.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,11 +151,14 @@ jobs:
     - uses: actions/checkout@v4.1.1
 
     - name: Install Windows Store Python
+      id: install
       uses: ./.github/actions/install-win-store-python
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Test Windows Store Python Install
+      # since Win store install can fallback to GitHub Python...only verify on success
+      if: steps.install.outputs.win-store-install-outcome == 'success'
       shell: powershell
       run: |
         $PythonExeSubDir = "\Microsoft\WindowsApps\PythonSoftwareFoundation.Python.${{ matrix.python-version }}_qbz5n2kfra8p0\python.exe"


### PR DESCRIPTION
## Changes
- Cloudflare started blocking access to the rg-adguard API from GitHub runners
  - See https://github.com/beeware/.github/pull/64
- This implements a temporary workaround to fallback to installing GitHub's Python to avoid breaking dependent workflows

## Notes
- Workflows in several repos depend on this action to succeed...so, this serves as at least a bandaid to avoid breaking CI in a bunch of places...especially given this will start failing downstream as soon as a cache miss happens...which is guaranteed at the end of the month.
- This obviously isn't a good long-term solution, though

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
