### PR TITLE
 Add reusable actions to create and/or verify a new project 

### DIFF
--- a/.github/actions/app-create/action.yml
+++ b/.github/actions/app-create/action.yml
@@ -1,0 +1,85 @@
+name: Create a Briefcase Project
+description: Creates a new Briefcase project using a particular GUI toolkit and template.
+
+inputs:
+  framework:
+    description: "The GUI toolkit to use to create the project."
+    default: "Toga"
+  briefcase-template-source:
+    description: "The template to use to roll out the project."
+    required: false
+  briefcase-template-branch:
+    description: "The git branch for the template to use to roll out the project."
+    required: false
+  testing-pr-body:
+    description: "Override value for body of PR; only for testing."
+    required: false
+
+outputs:
+  project-path:
+    value: ${{ steps.create.outputs.path }}
+    description: "The file path to the root of the created project."
+
+runs:
+  using: composite
+  steps:
+    - name: Briefcase Template Override
+      id: template-override
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      shell: bash
+      run: |
+        # Check Body of PR for template to use
+        # (only PRs will have a value for github.event.pull_request.number)
+        PR_BODY="${{ inputs.testing-pr-body }}"
+        if [[ -z "${PR_BODY}" && -n "${{ github.event.pull_request.number }}" ]]; then
+          PR_BODY=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} --jq '.body')
+        fi
+        printf "::group::Retrieved PR Body\n%s\n::endgroup::\n" "${PR_BODY}"
+
+        TEMPLATE_REPO=$(printf "%s" "${PR_BODY}" | perl -wlne '/BRIEFCASE[-_]*TEMPLATE[-_]*REPO:\s*\K\S+/i and print $&')
+        TEMPLATE_REF=$(printf "%s" "${PR_BODY}" | perl -wlne '/BRIEFCASE[-_]*TEMPLATE[-_]*REF:\s*\K\S+/i and print $&')
+
+        # Expose template repo and branch via outputs
+        echo "repo=${TEMPLATE_REPO}" | tee -a ${GITHUB_OUTPUT}
+        echo "ref=${TEMPLATE_REF}" | tee -a ${GITHUB_OUTPUT}
+
+    - name: Create Briefcase Project
+      id: create
+      shell: bash
+      run: |
+        if [[ "${{ steps.template-override.outputs.repo }}" != "" ]]; then
+          TEMPLATE=$(printf -- "--template %q" "${{ steps.template-override.outputs.repo }}")
+        fi
+        if [[ "${{ steps.template-override.outputs.ref }}" != "" ]]; then
+          TEMPLATE_BRANCH=$(printf -- "--template-branch %q" "${{ steps.template-override.outputs.ref }}")
+        fi
+
+        # Map the requested GUI toolkit to the input that Briefcase expects
+        # Default to the input to accommodate arbitrary toolkits installed as plugins
+        case "$(tr '[:upper:]' '[:lower:]' <<< '${{ inputs.framework }}')" in
+          toga    ) GUI_INPUT=1 ;;
+          pyside6 ) GUI_INPUT=2 ;;
+          ppb     ) GUI_INPUT=3 ;;
+          pygame  ) GUI_INPUT=4 ;;
+          *       ) GUI_INPUT=${{ inputs.framework }} ;;
+        esac
+
+        ROOT_DIR="apps"
+        APP_NAME="Verify App"
+        APP_DIR="verifyapp"
+        APP_PATH="${ROOT_DIR}/${APP_DIR}"
+
+        # Prepare to create the project in APP_DIR
+        mkdir -p "${ROOT_DIR}"
+        cd "${ROOT_DIR}"
+        rm -rf "${APP_DIR}"
+
+        # Roll out the project
+        printf "%s\n%s\n\n\n\n\n\n\n\n%s\n" "${APP_NAME}" "${APP_DIR}" "${GUI_INPUT}" \
+          | briefcase new ${TEMPLATE} ${TEMPLATE_BRANCH}
+
+        echo "Rolled out project to ${APP_PATH} (${{ inputs.framework }}->${GUI_INPUT})"
+        printf "::group::pyproject.toml\n%s\n::endgroup::\n" "$(cat "${APP_DIR}/pyproject.toml")"
+        printf "::group::app.py\n%s\n::endgroup::\n" "$(cat "${APP_DIR}/src/${APP_DIR}/app.py")"
+        echo "path=${APP_PATH}" >> ${GITHUB_OUTPUT}

--- a/.github/actions/app-create/action.yml
+++ b/.github/actions/app-create/action.yml
@@ -40,6 +40,14 @@ runs:
         TEMPLATE_REPO=$(printf "%s" "${PR_BODY}" | perl -wlne '/BRIEFCASE[-_]*TEMPLATE[-_]*REPO:\s*\K\S+/i and print $&')
         TEMPLATE_REF=$(printf "%s" "${PR_BODY}" | perl -wlne '/BRIEFCASE[-_]*TEMPLATE[-_]*REF:\s*\K\S+/i and print $&')
 
+        # If a template is not in the PR, use inputs specified in CI workflow
+        if [ -z "${TEMPLATE_REPO}" ]; then
+          TEMPLATE_REPO="${{ inputs.briefcase-template-source }}"
+        fi
+        if [ -z "${TEMPLATE_REF}" ]; then
+          TEMPLATE_REF="${{ inputs.briefcase-template-branch }}"
+        fi
+
         # Expose template repo and branch via outputs
         echo "repo=${TEMPLATE_REPO}" | tee -a ${GITHUB_OUTPUT}
         echo "ref=${TEMPLATE_REF}" | tee -a ${GITHUB_OUTPUT}

--- a/.github/actions/install-briefcase/action.yml
+++ b/.github/actions/install-briefcase/action.yml
@@ -38,8 +38,8 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
       shell: bash
       run: |
-        # Source version from Body of PR (if there is one; if there isn't,
-        # github.event.pull_request.number will be empty)
+        # Check Body of PR for Briefcase version to use
+        # (only PRs will have a value for github.event.pull_request.number)
         PR_BODY="${{ inputs.testing-pr-body }}"
         if [[ -z "${PR_BODY}" && -n "${{ github.event.pull_request.number }}" ]]; then
           PR_BODY=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} --jq '.body')
@@ -58,10 +58,8 @@ runs:
         fi
 
         # Expose repo and version via outputs
-        echo "Briefcase Repo: ${BRIEFCASE_REPO}"
-        echo "Briefcase Ref: ${BRIEFCASE_REF}"
-        echo "repo=${BRIEFCASE_REPO}" >> ${GITHUB_OUTPUT}
-        echo "ref=${BRIEFCASE_REF}" >> ${GITHUB_OUTPUT}
+        echo "repo=${BRIEFCASE_REPO}" | tee -a ${GITHUB_OUTPUT}
+        echo "ref=${BRIEFCASE_REF}" | tee -a ${GITHUB_OUTPUT}
 
     - name: Derive Target Briefcase Version
       id: briefcase-derived

--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -120,12 +120,18 @@ jobs:
       # if: ${{ !endsWith(inputs.repository, 'briefcase') }}
       uses: ./beeware-.github/.github/actions/install-briefcase
 
+    - name: Determine Briefcase Template Path
+      # If the briefcase-template repo is being tested, use the current checkout
+      id: template
+      if: endsWith(inputs.repository, 'briefcase-template')
+      run: echo "path=${{ github.workspace }}" | tee -a ${GITHUB_OUTPUT}
+
     - name: Create Briefcase Project
       id: create
       uses: ./beeware-.github/.github/actions/app-create
       with:
         framework: ${{ inputs.framework }}
-        briefcase-template-source: ${{ inputs.briefcase-template-source }}
+        briefcase-template-source: ${{ inputs.briefcase-template-source || steps.template.outputs.path }}
         briefcase-template-branch: ${{ inputs.briefcase-template-branch }}
 
     - name: Determine Output Format Configuration
@@ -134,9 +140,8 @@ jobs:
       if: endsWith(inputs.repository, '-template') && inputs.repository != 'beeware/briefcase-template'
       id: output-format
       run: |
-        # The current repo is cloned in to the current directory; that will
-        # be up levels up in the file system from the root of the app project
-        echo "template-override=--config 'template=\"../../\"'" | tee -a ${GITHUB_OUTPUT}
+        # Since the current repo is cloned in to the workspace, use it for the template
+        echo "template-override=$(printf -- "--config template=%q" "'${{ github.workspace }}'")" | tee -a ${GITHUB_OUTPUT}
 
     # In the steps below, using the builtin functions for comparison (instead of ==)
     # allows for case-insensitivity to the inputs for the workflow.
@@ -148,7 +153,8 @@ jobs:
         && contains(fromJSON('["", "app"]'), inputs.target-format)
       working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        briefcase create macOS app ${{ steps.output-format.outputs.template-override }}
+        briefcase create macOS app \
+          ${{ steps.output-format.outputs.template-override }}
         briefcase build macOS app
         briefcase package macOS app --adhoc-sign
 
@@ -159,7 +165,8 @@ jobs:
         && contains(fromJSON('["", "Xcode"]'), inputs.target-format)
       working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        briefcase create macOS Xcode ${{ steps.output-format.outputs.template-override }}
+        briefcase create macOS Xcode \
+          ${{ steps.output-format.outputs.template-override }}
         briefcase build macOS Xcode
         briefcase package macOS Xcode --adhoc-sign
 
@@ -172,7 +179,8 @@ jobs:
         WIX: ""  # force Briefcase to install and use its own version of WiX
       working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        briefcase create windows app ${{ steps.output-format.outputs.template-override }}
+        briefcase create windows app \
+          ${{ steps.output-format.outputs.template-override }}
         briefcase build windows app
         briefcase package windows app --adhoc-sign
 
@@ -185,7 +193,8 @@ jobs:
         WIX: ""  # force Briefcase to install and use its own version of WiX
       working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        briefcase create windows VisualStudio ${{ steps.output-format.outputs.template-override }}
+        briefcase create windows VisualStudio \
+          ${{ steps.output-format.outputs.template-override }}
         briefcase build windows VisualStudio
         briefcase package windows VisualStudio --adhoc-sign
 
@@ -200,7 +209,8 @@ jobs:
         sudo apt update -y
         sudo apt install -y --no-install-recommends python3-dev python3-pip libcairo2-dev libgirepository1.0-dev
 
-        briefcase create linux system ${{ steps.output-format.outputs.template-override }}
+        briefcase create linux system \
+          ${{ steps.output-format.outputs.template-override }}
         briefcase build linux system
         briefcase package linux system --adhoc-sign
 
@@ -211,7 +221,8 @@ jobs:
         && contains(fromJSON('["", "system"]'), inputs.target-format)
       working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        briefcase create linux system --target debian:bullseye ${{ steps.output-format.outputs.template-override }}
+        briefcase create linux system --target debian:bullseye \
+          ${{ steps.output-format.outputs.template-override }}
         briefcase build linux system --target debian:bullseye
         briefcase package linux system --target debian:bullseye --adhoc-sign
 
@@ -222,7 +233,8 @@ jobs:
         && contains(fromJSON('["", "system"]'), inputs.target-format)
       working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        briefcase create linux system --target fedora:37 ${{ steps.output-format.outputs.template-override }}
+        briefcase create linux system --target fedora:37 \
+          ${{ steps.output-format.outputs.template-override }}
         briefcase build linux system --target fedora:37
         briefcase package linux system --target fedora:37 --adhoc-sign
 
@@ -233,7 +245,8 @@ jobs:
         && contains(fromJSON('["", "system"]'), inputs.target-format)
       working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        briefcase create linux system --target archlinux:latest ${{ steps.output-format.outputs.template-override }}
+        briefcase create linux system --target archlinux:latest \
+          ${{ steps.output-format.outputs.template-override }}
         briefcase build linux system --target archlinux:latest
         briefcase package linux system --target archlinux:latest --adhoc-sign
 
@@ -261,12 +274,12 @@ jobs:
         # so, the version will need to be constrained to successfully build an AppImage with Toga.
         # Furthermore, Toga>0.3.1 requires PyGObject>=3.46.0 so its version is constrained as well.
         if [ "${{ startsWith(inputs.framework, 'toga') }}" = "true" ]; then
-          CONFIG_OVERRIDE_REQUIRES='requires=["toga-gtk==0.3.1", "PyGobject<3.46.0"]'
+          CONFIG_OVERRIDE_REQUIRES='--config requires=["toga-gtk==0.3.1","PyGobject<3.46.0"]'
         fi
 
         briefcase create linux AppImage \
           ${{ steps.output-format.outputs.template-override }} \
-          --config $(printf '%s' $CONFIG_OVERRIDE_REQUIRES)
+          ${CONFIG_OVERRIDE_REQUIRES}
         briefcase build linux AppImage
         briefcase package linux AppImage --adhoc-sign
 
@@ -281,7 +294,8 @@ jobs:
         sudo apt update -y
         sudo apt install -y --no-install-recommends flatpak flatpak-builder elfutils
 
-        briefcase create linux flatpak ${{ steps.output-format.outputs.template-override }}
+        briefcase create linux flatpak \
+          ${{ steps.output-format.outputs.template-override }}
         briefcase build linux flatpak
         briefcase package linux flatpak --adhoc-sign
 
@@ -292,7 +306,8 @@ jobs:
         && startsWith(inputs.framework, 'toga')
       working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        briefcase create android gradle ${{ steps.output-format.outputs.template-override }}
+        briefcase create android gradle \
+          ${{ steps.output-format.outputs.template-override }}
         briefcase build android gradle
         briefcase package android gradle --adhoc-sign
 
@@ -304,7 +319,8 @@ jobs:
         && startsWith(inputs.framework, 'toga')
       working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        briefcase create iOS xcode ${{ steps.output-format.outputs.template-override }}
+        briefcase create iOS xcode \
+          ${{ steps.output-format.outputs.template-override }}
         briefcase build iOS xcode
         briefcase package iOS xcode --adhoc-sign
 
@@ -315,7 +331,8 @@ jobs:
         && startsWith(inputs.framework, 'toga')
       working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        briefcase create web static ${{ steps.output-format.outputs.template-override }}
+        briefcase create web static \
+          ${{ steps.output-format.outputs.template-override }}
         briefcase build web static
         briefcase package web static
 

--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -63,10 +63,11 @@ jobs:
     - name: Checkout beeware/.github
       uses: actions/checkout@v4.1.1
       with:
-        repository: "beeware/.github"
-        path: "beeware-.github"
+        repository: rmartin16/.github-beeware  # !!!! TODO:PR: REPLACE ME WITH beeware/.github !!!!
+        ref: create-new-project  # !!!! TODO:PR: REMOVE ME !!!!
+        path: beeware-.github
 
-    - name: Package name
+    - name: Package Name
       id: package
       run: echo "name=$(basename '${{ inputs.repository }}')" >> ${GITHUB_OUTPUT}
 
@@ -90,7 +91,7 @@ jobs:
           echo "docker-cache-dir=C:/ProgramData/DockerDesktop" >> ${GITHUB_OUTPUT}
         fi
 
-    - name: Cache Briefcase tools
+    - name: Cache Briefcase Tools
       uses: actions/cache@v3.3.2
       with:
         key: briefcase-${{ runner.os }}-${{ inputs.repository }}-${{ inputs.framework }}-${{ inputs.target-platform }}-${{ inputs.target-format }}
@@ -103,15 +104,15 @@ jobs:
     - name: Determine system python3 version
       id: system-python
       run: |
-        echo "python-version=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
-        echo "python-version=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')" >> ${GITHUB_OUTPUT}
+        SYSTEM_PYTHON_VER=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+        echo "version=${SYSTEM_PYTHON_VER}" | tee -a ${GITHUB_OUTPUT}
 
     - name: Set up Python
       uses: actions/setup-python@v4.7.1
       with:
         python-version: ${{ inputs.python-version }}
 
-    - name: Get packages
+    - name: Get Packages
       # Briefcase will build and package itself in a previous step in its CI.
       if: endsWith(inputs.repository, 'briefcase')
       uses: actions/download-artifact@v3.0.2
@@ -119,124 +120,126 @@ jobs:
         name: packages-${{ steps.package.outputs.name }}
         path: dist
 
-    - name: Install Briefcase artifact
-      if: endsWith(inputs.repository, 'briefcase')
-      run: python -m pip install dist/briefcase-*.whl
+    # !!!!!  TODO:PR: RESTORE INSTALLING BRIEFCASE ARTEFACT - INSTALL FROM PR BODY ALWAYS FOR TESTING !!!!!
+    # - name: Install Briefcase Artefact
+    #   if: endsWith(inputs.repository, 'briefcase')
+    #   run: python -m pip install dist/briefcase-*.whl
 
     - name: Install Briefcase
-      if: ${{ !endsWith(inputs.repository, 'briefcase') }}
+      # if: ${{ !endsWith(inputs.repository, 'briefcase') }}
       uses: ./beeware-.github/.github/actions/install-briefcase
 
-    - name: Create Briefcase project
-      # Don't run for template repos since they already contain a created app.
-      if: ${{ !endsWith(inputs.repository, '-template') || inputs.repository == 'beeware/briefcase-template' }}
+    - name: Create Briefcase Project
+      id: create
+      uses: ./beeware-.github/.github/actions/app-create
+      with:
+        framework: ${{ inputs.framework }}
+        briefcase-template-source: ${{ inputs.briefcase-template-source }}
+        briefcase-template-branch: ${{ inputs.briefcase-template-branch }}
+
+    - name: Determine Output Format Configuration
+      if: endsWith(inputs.repository, '-template') && inputs.repository != 'beeware/briefcase-template'
+      id: output-format
       run: |
-        if [[ "${{ inputs.briefcase-template-source }}" != "" ]]; then
-          TEMPLATE=$(printf -- "--template %q" "${{ inputs.briefcase-template-source }}")
-        fi
-        if [[ "${{ inputs.briefcase-template-branch }}" != "" ]]; then
-          TEMPLATE_BRANCH=$(printf -- "--template-branch %q" "${{ inputs.briefcase-template-branch }}")
-        fi
-        cd tests/apps
-        cat verify-${{ inputs.framework }}.config | briefcase new ${TEMPLATE} ${TEMPLATE_BRANCH}
+        # The current repo is cloned in to the current directory; that will
+        # be up levels up in the file system from the root of the app project
+        echo "template-override=--config 'template=\"../../\"'" | tee -a ${GITHUB_OUTPUT}
 
     # In the steps below, using the builtin functions for comparison (instead of ==)
     # allows for case-insensitivity to the inputs for the workflow.
 
-    - name: Build macOS app
+    - name: Build macOS App
       if: >
         startsWith(inputs.runner-os, 'macOS')
         && contains(fromJSON('["", "macOS"]'), inputs.target-platform)
         && contains(fromJSON('["", "app"]'), inputs.target-format)
+      working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        cd tests/apps/verify-${{ inputs.framework }}
         briefcase create macOS app
         briefcase build macOS app
         briefcase package macOS app --adhoc-sign
 
-    - name: Build macOS Xcode project
+    - name: Build macOS Xcode Project
       if: >
         startsWith(inputs.runner-os, 'macOS')
         && contains(fromJSON('["", "macOS"]'), inputs.target-platform)
         && contains(fromJSON('["", "Xcode"]'), inputs.target-format)
+      working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        cd tests/apps/verify-${{ inputs.framework }}
         briefcase create macOS Xcode
         briefcase build macOS Xcode
         briefcase package macOS Xcode --adhoc-sign
 
-    - name: Build Windows app
+    - name: Build Windows App
       if: >
         startsWith(inputs.runner-os, 'Windows')
         && contains(fromJSON('["", "Windows"]'), inputs.target-platform)
         && contains(fromJSON('["", "app"]'), inputs.target-format)
+      env:
+        WIX: ""  # force Briefcase to install and use its own version of WiX
+      working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        unset WIX  # force Briefcase to install and use its own version of WiX
-
-        cd tests/apps/verify-${{ inputs.framework }}
         briefcase create windows app
         briefcase build windows app
         briefcase package windows app --adhoc-sign
 
-    - name: Build Windows Visual Studio project
+    - name: Build Windows Visual Studio Project
       if: >
         startsWith(inputs.runner-os, 'Windows')
         && contains(fromJSON('["", "Windows"]'), inputs.target-platform)
         && contains(fromJSON('["", "VisualStudio"]'), inputs.target-format)
+      env:
+        WIX: ""  # force Briefcase to install and use its own version of WiX
+      working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        unset WIX  # force Briefcase to install and use its own version of WiX
-
-        cd tests/apps/verify-${{ inputs.framework }}
         briefcase create windows VisualStudio
         briefcase build windows VisualStudio
         briefcase package windows VisualStudio --adhoc-sign
 
-    - name: Build Linux System project (Ubuntu, local)
+    - name: Build Linux System Project (Ubuntu, local)
       if: >
         startsWith(inputs.runner-os, 'ubuntu')
-        && startsWith(inputs.python-version, steps.system-python.outputs.python-version)
+        && startsWith(inputs.python-version, steps.system-python.outputs.version)
         && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
         && contains(fromJSON('["", "system"]'), inputs.target-format)
+      working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        sudo apt-get update -y && sudo apt-get install -y python3-dev python3-pip libcairo2-dev libgirepository1.0-dev
-        cd tests/apps/verify-${{ inputs.framework }}
+        sudo apt update -y
+        sudo apt install -y --no-install-recommends python3-dev python3-pip libcairo2-dev libgirepository1.0-dev
+
         briefcase create linux system
         briefcase build linux system
         briefcase package linux system --adhoc-sign
 
-    - name: Build Linux System project (Debian, Dockerized)
+    - name: Build Linux System Project (Debian, Dockerized)
       if: >
         startsWith(inputs.runner-os, 'ubuntu')
         && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
         && contains(fromJSON('["", "system"]'), inputs.target-format)
+      working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        cd tests/apps/verify-${{ inputs.framework }}
         briefcase create linux system --target debian:bullseye
         briefcase build linux system --target debian:bullseye
         briefcase package linux system --target debian:bullseye --adhoc-sign
 
-    - name: Build Linux System project (RPM, Dockerized)
-      # fedora:37 ships with Python 3.11 and PySide2 cannot be installed
+    - name: Build Linux System Project (RPM, Dockerized)
       if: >
         startsWith(inputs.runner-os, 'ubuntu')
-        && !contains(fromJSON('["PySide2"]'), inputs.framework)
         && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
         && contains(fromJSON('["", "system"]'), inputs.target-format)
+      working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        cd tests/apps/verify-${{ inputs.framework }}
         briefcase create linux system --target fedora:37
         briefcase build linux system --target fedora:37
         briefcase package linux system --target fedora:37 --adhoc-sign
 
-    - name: Build Linux System project (Arch, Dockerized)
-      # arch started shipping Python 3.11 on 3 may 2023 and PySide2 cannot be installed
+    - name: Build Linux System Project (Arch, Dockerized)
       if: >
         startsWith(inputs.runner-os, 'ubuntu')
-        && !contains(fromJSON('["PySide2"]'), inputs.framework)
         && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
         && contains(fromJSON('["", "system"]'), inputs.target-format)
+      working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        cd tests/apps/verify-${{ inputs.framework }}
         briefcase create linux system --target archlinux:latest
         briefcase build linux system --target archlinux:latest
         briefcase package linux system --target archlinux:latest --adhoc-sign
@@ -254,28 +257,30 @@ jobs:
     # alive.
     #
     # Only runs when target platform and format are explicitly Linux and AppImage.
-    - name: Build AppImage project
+    - name: Build AppImage Project
       if: >
         startsWith(inputs.runner-os, 'ubuntu')
         && contains(fromJSON('["Linux"]'), inputs.target-platform)
         && contains(fromJSON('["AppImage"]'), inputs.target-format)
+      working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        cd tests/apps/verify-${{ inputs.framework }}
-        briefcase create linux AppImage
+        briefcase create linux AppImage \
+          ${{ steps.output-format.outputs.template-override }} \
+          --config 'requires=["toga-gtk==0.3.1", "PyGobject<3.46.0"]'
         briefcase build linux AppImage
         briefcase package linux AppImage --adhoc-sign
 
-    - name: Build Flatpak project
+    - name: Build Flatpak Project
       if: >
         startsWith(inputs.runner-os, 'ubuntu')
         && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
         && contains(fromJSON('["", "Flatpak"]'), inputs.target-format)
         && contains(fromJSON('["Toga", "PyGame"]'), inputs.framework)
+      working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        sudo apt-get update -y
-        sudo apt-get install -y flatpak flatpak-builder
+        sudo apt update -y
+        sudo apt install -y --no-install-recommends flatpak flatpak-builder elfutils
 
-        cd tests/apps/verify-${{ inputs.framework }}
         briefcase create linux flatpak
         briefcase build linux flatpak
         briefcase package linux flatpak --adhoc-sign
@@ -285,8 +290,8 @@ jobs:
         contains(fromJSON('["", "Android"]'), inputs.target-platform)
         && contains(fromJSON('["", "Gradle"]'), inputs.target-format)
         && startsWith(inputs.framework, 'toga')
+      working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        cd tests/apps/verify-${{ inputs.framework }}
         briefcase create android gradle
         briefcase build android gradle
         briefcase package android gradle --adhoc-sign
@@ -297,8 +302,8 @@ jobs:
         && contains(fromJSON('["", "iOS"]'), inputs.target-platform)
         && contains(fromJSON('["", "Xcode"]'), inputs.target-format)
         && startsWith(inputs.framework, 'toga')
+      working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        cd tests/apps/verify-${{ inputs.framework }}
         briefcase create iOS xcode
         briefcase build iOS xcode
         briefcase package iOS xcode --adhoc-sign
@@ -308,15 +313,15 @@ jobs:
         contains(fromJSON('["", "web"]'), inputs.target-platform)
         && contains(fromJSON('["", "static"]'), inputs.target-format)
         && startsWith(inputs.framework, 'toga')
+      working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        cd tests/apps/verify-${{ inputs.framework }}
         briefcase create web static
         briefcase build web static
         briefcase package web static
 
-    - name: Upload failure logs
+    - name: Upload Failure Logs
       uses: actions/upload-artifact@v3.1.3
       if: failure()
       with:
-        name: build-failure-logs-${{ inputs.framework }}-${{ inputs.python-version }}-${{ inputs.target-platform }}-${{ inputs.target-format }}
-        path: tests/apps/verify-${{ inputs.framework }}/logs/*
+        name: build-failure-logs-${{ inputs.runner-os }}-${{ inputs.framework }}-${{ inputs.python-version }}-${{ inputs.target-platform }}-${{ inputs.target-format }}
+        path: ${{ steps.create.outputs.project-path }}/logs/*

--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -102,6 +102,7 @@ jobs:
         cache-dependency-path: |
           **/setup.cfg
           **/pyproject.toml
+          .pre-commit-config.yaml
 
     - name: Get Packages
       # Briefcase will build and package itself in a previous step in its CI

--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -69,37 +69,24 @@ jobs:
 
     - name: Package Name
       id: package
-      run: echo "name=$(basename '${{ inputs.repository }}')" >> ${GITHUB_OUTPUT}
+      run: echo "name=$(basename '${{ inputs.repository }}')" | tee -a ${GITHUB_OUTPUT}
 
-    - name: Determine Cache Directories
+    - name: Determine Cache Directory
       id: dirs
       run: |
-        echo "cookiecutters-data-dir=~/.cookiecutters" >> ${GITHUB_OUTPUT}
-
-        if [[ "${{ startsWith(inputs.runner-os, 'ubuntu') }}" == "true" ]]; then
-          echo "briefcase-data-dir=~/.cache/briefcase" >> ${GITHUB_OUTPUT}
-          echo "pip-cache-dir=~/.cache/pip" >> ${GITHUB_OUTPUT}
-
-        elif [[ "${{ startsWith(inputs.runner-os, 'macos') }}" == "true" ]]; then
-          echo "briefcase-data-dir=~/Library/Caches/org.beeware.briefcase" >> ${GITHUB_OUTPUT}
-          echo "pip-cache-dir=~/Library/Caches/pip" >> ${GITHUB_OUTPUT}
-          echo "docker-cache-dir=~/Library/Containers/com.docker.docker/Data/vms/0/" >> ${GITHUB_OUTPUT}
-
-        elif [[ "${{ startsWith(inputs.runner-os, 'windows') }}" == "true" ]]; then
-          echo "briefcase-data-dir=~/AppData/Local/BeeWare/briefcase/Cache" >> ${GITHUB_OUTPUT}
-          echo "pip-cache-dir=~/AppData/Local/pip/Cache" >> ${GITHUB_OUTPUT}
-          echo "docker-cache-dir=C:/ProgramData/DockerDesktop" >> ${GITHUB_OUTPUT}
-        fi
+        case "$(tr '[:upper:]' '[:lower:]' <<< '${{ inputs.runner-os }}')" in
+          ubuntu*  ) BRIEFCASE_DIR="~/.cache/briefcase" ;;
+          macos*   ) BRIEFCASE_DIR="~/Library/Caches/org.beeware.briefcase" ;;
+          windows* ) BRIEFCASE_DIR="~/AppData/Local/BeeWare/briefcase/Cache" ;;
+          *        ) echo "::error::Failed to determine the Briefcase data directory path" ;;
+        esac
+        echo "briefcase-data-dir=${BRIEFCASE_DIR}" | tee -a ${GITHUB_OUTPUT}
 
     - name: Cache Briefcase Tools
       uses: actions/cache@v3.3.2
       with:
-        key: briefcase-${{ runner.os }}-${{ inputs.repository }}-${{ inputs.framework }}-${{ inputs.target-platform }}-${{ inputs.target-format }}
-        path: |
-          ${{ steps.dirs.outputs.cookiecutters-data-dir }}
-          ${{ steps.dirs.outputs.briefcase-data-dir }}
-          ${{ steps.dirs.outputs.pip-cache-dir }}
-          ${{ steps.dirs.outputs.docker-cache-dir }}
+        key: briefcase-data|${{ inputs.runner-os }}|${{ inputs.repository }}|${{ inputs.framework }}|${{ inputs.target-platform }}|${{ inputs.target-format }}
+        path: ${{ steps.dirs.outputs.briefcase-data-dir }}
 
     - name: Determine System python3 Version
       id: system-python
@@ -111,6 +98,10 @@ jobs:
       uses: actions/setup-python@v4.7.1
       with:
         python-version: ${{ inputs.python-version }}
+        cache: pip
+        cache-dependency-path: |
+          **/setup.cfg
+          **/pyproject.toml
 
     - name: Get Packages
       # Briefcase will build and package itself in a previous step in its CI

--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -101,19 +101,19 @@ jobs:
           ${{ steps.dirs.outputs.pip-cache-dir }}
           ${{ steps.dirs.outputs.docker-cache-dir }}
 
-    - name: Determine system python3 version
+    - name: Determine System python3 Version
       id: system-python
       run: |
         SYSTEM_PYTHON_VER=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
         echo "version=${SYSTEM_PYTHON_VER}" | tee -a ${GITHUB_OUTPUT}
 
-    - name: Set up Python
+    - name: Set Up Python
       uses: actions/setup-python@v4.7.1
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: Get Packages
-      # Briefcase will build and package itself in a previous step in its CI.
+      # Briefcase will build and package itself in a previous step in its CI
       if: endsWith(inputs.repository, 'briefcase')
       uses: actions/download-artifact@v3.0.2
       with:
@@ -138,6 +138,8 @@ jobs:
         briefcase-template-branch: ${{ inputs.briefcase-template-branch }}
 
     - name: Determine Output Format Configuration
+      # only used for the template repos so apps are built with the PR version of the template;
+      # other repos will fetch the latest template version during `create` as normal.
       if: endsWith(inputs.repository, '-template') && inputs.repository != 'beeware/briefcase-template'
       id: output-format
       run: |
@@ -155,7 +157,7 @@ jobs:
         && contains(fromJSON('["", "app"]'), inputs.target-format)
       working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        briefcase create macOS app
+        briefcase create macOS app ${{ steps.output-format.outputs.template-override }}
         briefcase build macOS app
         briefcase package macOS app --adhoc-sign
 
@@ -166,7 +168,7 @@ jobs:
         && contains(fromJSON('["", "Xcode"]'), inputs.target-format)
       working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        briefcase create macOS Xcode
+        briefcase create macOS Xcode ${{ steps.output-format.outputs.template-override }}
         briefcase build macOS Xcode
         briefcase package macOS Xcode --adhoc-sign
 
@@ -179,7 +181,7 @@ jobs:
         WIX: ""  # force Briefcase to install and use its own version of WiX
       working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        briefcase create windows app
+        briefcase create windows app ${{ steps.output-format.outputs.template-override }}
         briefcase build windows app
         briefcase package windows app --adhoc-sign
 
@@ -192,7 +194,7 @@ jobs:
         WIX: ""  # force Briefcase to install and use its own version of WiX
       working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        briefcase create windows VisualStudio
+        briefcase create windows VisualStudio ${{ steps.output-format.outputs.template-override }}
         briefcase build windows VisualStudio
         briefcase package windows VisualStudio --adhoc-sign
 
@@ -207,7 +209,7 @@ jobs:
         sudo apt update -y
         sudo apt install -y --no-install-recommends python3-dev python3-pip libcairo2-dev libgirepository1.0-dev
 
-        briefcase create linux system
+        briefcase create linux system ${{ steps.output-format.outputs.template-override }}
         briefcase build linux system
         briefcase package linux system --adhoc-sign
 
@@ -218,7 +220,7 @@ jobs:
         && contains(fromJSON('["", "system"]'), inputs.target-format)
       working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        briefcase create linux system --target debian:bullseye
+        briefcase create linux system --target debian:bullseye ${{ steps.output-format.outputs.template-override }}
         briefcase build linux system --target debian:bullseye
         briefcase package linux system --target debian:bullseye --adhoc-sign
 
@@ -229,7 +231,7 @@ jobs:
         && contains(fromJSON('["", "system"]'), inputs.target-format)
       working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        briefcase create linux system --target fedora:37
+        briefcase create linux system --target fedora:37 ${{ steps.output-format.outputs.template-override }}
         briefcase build linux system --target fedora:37
         briefcase package linux system --target fedora:37 --adhoc-sign
 
@@ -240,7 +242,7 @@ jobs:
         && contains(fromJSON('["", "system"]'), inputs.target-format)
       working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        briefcase create linux system --target archlinux:latest
+        briefcase create linux system --target archlinux:latest ${{ steps.output-format.outputs.template-override }}
         briefcase build linux system --target archlinux:latest
         briefcase package linux system --target archlinux:latest --adhoc-sign
 
@@ -264,9 +266,16 @@ jobs:
         && contains(fromJSON('["AppImage"]'), inputs.target-format)
       working-directory: ${{ steps.create.outputs.project-path }}
       run: |
+        # PyGObject>=3.46.0 requires a version of glibc that isn't available in manylinux images;
+        # so, the version will need to be constrained to successfully build an AppImage with Toga.
+        # Furthermore, Toga>0.3.1 requires PyGObject>=3.46.0 so its version is constrained as well.
+        if [ "${{ startsWith(inputs.framework, 'toga') }}" = "true" ]; then
+          CONFIG_OVERRIDE_REQUIRES='requires=["toga-gtk==0.3.1", "PyGobject<3.46.0"]'
+        fi
+
         briefcase create linux AppImage \
           ${{ steps.output-format.outputs.template-override }} \
-          --config 'requires=["toga-gtk==0.3.1", "PyGobject<3.46.0"]'
+          --config $(printf '%s' $CONFIG_OVERRIDE_REQUIRES)
         briefcase build linux AppImage
         briefcase package linux AppImage --adhoc-sign
 
@@ -281,7 +290,7 @@ jobs:
         sudo apt update -y
         sudo apt install -y --no-install-recommends flatpak flatpak-builder elfutils
 
-        briefcase create linux flatpak
+        briefcase create linux flatpak ${{ steps.output-format.outputs.template-override }}
         briefcase build linux flatpak
         briefcase package linux flatpak --adhoc-sign
 
@@ -292,7 +301,7 @@ jobs:
         && startsWith(inputs.framework, 'toga')
       working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        briefcase create android gradle
+        briefcase create android gradle ${{ steps.output-format.outputs.template-override }}
         briefcase build android gradle
         briefcase package android gradle --adhoc-sign
 
@@ -304,7 +313,7 @@ jobs:
         && startsWith(inputs.framework, 'toga')
       working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        briefcase create iOS xcode
+        briefcase create iOS xcode ${{ steps.output-format.outputs.template-override }}
         briefcase build iOS xcode
         briefcase package iOS xcode --adhoc-sign
 
@@ -315,7 +324,7 @@ jobs:
         && startsWith(inputs.framework, 'toga')
       working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        briefcase create web static
+        briefcase create web static ${{ steps.output-format.outputs.template-override }}
         briefcase build web static
         briefcase package web static
 

--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -63,8 +63,7 @@ jobs:
     - name: Checkout beeware/.github
       uses: actions/checkout@v4.1.1
       with:
-        repository: rmartin16/.github-beeware  # !!!! TODO:PR: REPLACE ME WITH beeware/.github !!!!
-        ref: create-new-project  # !!!! TODO:PR: REMOVE ME !!!!
+        repository: beeware/.github
         path: beeware-.github
 
     - name: Package Name
@@ -112,13 +111,12 @@ jobs:
         name: packages-${{ steps.package.outputs.name }}
         path: dist
 
-    # !!!!!  TODO:PR: RESTORE INSTALLING BRIEFCASE ARTEFACT - INSTALL FROM PR BODY ALWAYS FOR TESTING !!!!!
-    # - name: Install Briefcase Artefact
-    #   if: endsWith(inputs.repository, 'briefcase')
-    #   run: python -m pip install dist/briefcase-*.whl
+    - name: Install Briefcase Artefact
+      if: endsWith(inputs.repository, 'briefcase')
+      run: python -m pip install dist/briefcase-*.whl
 
     - name: Install Briefcase
-      # if: ${{ !endsWith(inputs.repository, 'briefcase') }}
+      if: ${{ !endsWith(inputs.repository, 'briefcase') }}
       uses: ./beeware-.github/.github/actions/install-briefcase
 
     - name: Determine Briefcase Template Path

--- a/.github/workflows/app-create-verify.yml
+++ b/.github/workflows/app-create-verify.yml
@@ -50,15 +50,13 @@ jobs:
     - name: Checkout beeware/.github
       uses: actions/checkout@v4.1.1
       with:
-        repository: rmartin16/.github-beeware  # !!!! TODO:PR: REPLACE ME WITH beeware/.github !!!!
-        ref: create-new-project  # !!!! TODO:PR: REMOVE ME !!!!
+        repository: beeware/.github
         path: beeware-.github
 
     - name: Checkout beeware/briefcase-template
       uses: actions/checkout@v4.1.1
       with:
-        repository: rmartin16/briefcase-template  # !!!!! TODO:PR: REPLACE ME WITH beeware/briefcase-template !!!!!
-        ref: gui-plugin-support  # !!!!! TODO:PR REMOVE ME !!!!!
+        repository: beeware/briefcase-template
         path: briefcase-template
 
     - name: Package Name

--- a/.github/workflows/app-create-verify.yml
+++ b/.github/workflows/app-create-verify.yml
@@ -59,16 +59,14 @@ jobs:
       id: package
       run: echo "name=$(basename '${{ inputs.repository }}')" >> ${GITHUB_OUTPUT}
 
-    - name: Cache Briefcase Tools
-      uses: actions/cache@v3.3.2
-      with:
-        key: briefcase-${{ runner.os }}-${{ inputs.framework }}
-        path: ~/.cookiecutters
-
     - name: Set up Python
       uses: actions/setup-python@v4.7.1
       with:
         python-version: ${{ inputs.python-version }}
+        cache: "pip"
+        cache-dependency-path: |
+          **/setup.cfg
+          **/pyproject.toml
 
     - name: Get Packages
       # Briefcase will build and package itself in a previous step in its CI

--- a/.github/workflows/app-create-verify.yml
+++ b/.github/workflows/app-create-verify.yml
@@ -1,0 +1,129 @@
+name: Verify Project
+
+#######
+# Verify creating a project for a target framework on a particular OS.
+#######
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: "Python version to use; defaults to latest Python release."
+        default: "3.X"
+        type: string
+      runner-os:
+        description: "The OS to use to build the App; must be a fully qualified GitHub runner OS, e.g. ubuntu-latest."
+        required: true
+        type: string
+      framework:
+        description: "Framework to use to build the App, e.g. toga."
+        required: true
+        type: string
+      briefcase-template-source:
+        description: "Path to use for --template for `briefcase new` to create app."
+        default: ""
+        type: string
+      briefcase-template-branch:
+        description: "Git branch to use for --template-branch for `briefcase new` to create app."
+        default: ""
+        type: string
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  FORCE_COLOR: "1"
+
+jobs:
+  verify-app:
+    name: Verify App Create
+    runs-on: ${{ inputs.runner-os }}
+    steps:
+
+    - name: Checkout beeware/.github
+      uses: actions/checkout@v4.1.1
+      with:
+        repository: rmartin16/.github-beeware  # !!!! TODO:PR: REPLACE ME WITH beeware/.github !!!!
+        ref: create-new-project  # !!!! TODO:PR: REMOVE ME !!!!
+        path: beeware-.github
+
+    - name: Checkout beeware/briefcase-template
+      uses: actions/checkout@v4.1.1
+      with:
+        repository: rmartin16/briefcase-template  # !!!!! TODO:PR: REPLACE ME WITH beeware/briefcase-template !!!!!
+        ref: gui-plugin-support  # !!!!! TODO:PR REMOVE ME !!!!!
+        path: briefcase-template
+
+    - name: Package Name
+      id: package
+      run: echo "name=$(basename '${{ inputs.repository }}')" >> ${GITHUB_OUTPUT}
+
+    - name: Cache Briefcase Tools
+      uses: actions/cache@v3.3.2
+      with:
+        key: briefcase-${{ runner.os }}-${{ inputs.framework }}
+        path: ~/.cookiecutters
+
+    - name: Set up Python
+      uses: actions/setup-python@v4.7.1
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Get Packages
+      # Briefcase will build and package itself in a previous step in its CI
+      if: endsWith(inputs.repository, 'briefcase')
+      uses: actions/download-artifact@v3.0.2
+      with:
+        name: packages-${{ steps.package.outputs.name }}
+        path: dist
+
+    - name: Install Dependencies
+      run: python -m pip install -Ur ./briefcase-template/requirements.txt
+
+    - name: Install Briefcase Artefact
+      if: endsWith(inputs.repository, 'briefcase')
+      run: python -m pip install dist/briefcase-*.whl
+
+    - name: Install Briefcase
+      if: ${{ !endsWith(inputs.repository, 'briefcase') }}
+      uses: ./beeware-.github/.github/actions/install-briefcase
+
+    - name: Create Briefcase project
+      id: create
+      uses: ./beeware-.github/.github/actions/app-create
+      with:
+        framework: ${{ inputs.framework }}
+        briefcase-template-source: ${{ inputs.briefcase-template-source }}
+        briefcase-template-branch: ${{ inputs.briefcase-template-branch }}
+
+    - name: Run Flake8
+      working-directory: ${{ steps.create.outputs.project-path }}
+      run: flake8 --select=E
+
+    - name: Validate pyproject.toml
+      working-directory: ${{ steps.create.outputs.project-path }}
+      shell: python
+      run: |
+        import toml
+        from pathlib import Path
+        from pprint import pprint
+
+        pyproject_toml = Path().cwd() / "pyproject.toml"
+        assert pyproject_toml.is_file()
+        pprint(toml.load(pyproject_toml))
+
+    - name: Install Dependencies (Ubuntu)
+      if: startsWith(inputs.runner-os, 'ubuntu')
+      run: sudo apt update -y && sudo apt install -y --no-install-recommends libgirepository1.0-dev
+
+    - name: Test Project Build
+      working-directory: ${{ steps.create.outputs.project-path }}
+      run: briefcase build
+
+    - name: Upload failure logs
+      uses: actions/upload-artifact@v3.1.3
+      if: failure()
+      with:
+        name: build-failure-logs-${{ inputs.runner-os }}-${{ inputs.framework }}-${{ inputs.python-version }}
+        path: ${{ steps.create.outputs.project-path }}/logs/*

--- a/.github/workflows/app-create-verify.yml
+++ b/.github/workflows/app-create-verify.yml
@@ -113,14 +113,6 @@ jobs:
         assert pyproject_toml.is_file()
         pprint(toml.load(pyproject_toml))
 
-    - name: Install Dependencies (Ubuntu)
-      if: startsWith(inputs.runner-os, 'ubuntu')
-      run: sudo apt update -y && sudo apt install -y --no-install-recommends libgirepository1.0-dev
-
-    - name: Test Project Build
-      working-directory: ${{ steps.create.outputs.project-path }}
-      run: briefcase build
-
     - name: Upload failure logs
       uses: actions/upload-artifact@v3.1.3
       if: failure()

--- a/.github/workflows/app-create-verify.yml
+++ b/.github/workflows/app-create-verify.yml
@@ -41,6 +41,12 @@ jobs:
     runs-on: ${{ inputs.runner-os }}
     steps:
 
+    - name: Checkout ${{ github.repository }}
+      uses: actions/checkout@v4.1.1
+      with:
+        repository: ${{ github.repository }}
+        fetch-depth: 0
+
     - name: Checkout beeware/.github
       uses: actions/checkout@v4.1.1
       with:
@@ -57,20 +63,20 @@ jobs:
 
     - name: Package Name
       id: package
-      run: echo "name=$(basename '${{ inputs.repository }}')" >> ${GITHUB_OUTPUT}
+      run: echo "name=$(basename '${{ github.repository }}')" >> ${GITHUB_OUTPUT}
 
     - name: Set up Python
       uses: actions/setup-python@v4.7.1
       with:
         python-version: ${{ inputs.python-version }}
-        cache: "pip"
+        cache: pip
         cache-dependency-path: |
           **/setup.cfg
           **/pyproject.toml
 
     - name: Get Packages
       # Briefcase will build and package itself in a previous step in its CI
-      if: endsWith(inputs.repository, 'briefcase')
+      if: endsWith(github.repository, 'briefcase')
       uses: actions/download-artifact@v3.0.2
       with:
         name: packages-${{ steps.package.outputs.name }}
@@ -80,19 +86,25 @@ jobs:
       run: python -m pip install -Ur ./briefcase-template/requirements.txt
 
     - name: Install Briefcase Artefact
-      if: endsWith(inputs.repository, 'briefcase')
+      if: endsWith(github.repository, 'briefcase')
       run: python -m pip install dist/briefcase-*.whl
 
     - name: Install Briefcase
-      if: ${{ !endsWith(inputs.repository, 'briefcase') }}
+      if: ${{ !endsWith(github.repository, 'briefcase') }}
       uses: ./beeware-.github/.github/actions/install-briefcase
+
+    - name: Determine Briefcase Template Path
+      # If the briefcase-template repo is being tested, use the current checkout
+      id: template
+      if: endsWith(github.repository, 'briefcase-template')
+      run: echo "path=${{ github.workspace }}" | tee -a ${GITHUB_OUTPUT}
 
     - name: Create Briefcase project
       id: create
       uses: ./beeware-.github/.github/actions/app-create
       with:
         framework: ${{ inputs.framework }}
-        briefcase-template-source: ${{ inputs.briefcase-template-source }}
+        briefcase-template-source: ${{ inputs.briefcase-template-source || steps.template.outputs.path }}
         briefcase-template-branch: ${{ inputs.briefcase-template-branch }}
 
     - name: Run Flake8

--- a/.github/workflows/app-create-verify.yml
+++ b/.github/workflows/app-create-verify.yml
@@ -73,6 +73,7 @@ jobs:
         cache-dependency-path: |
           **/setup.cfg
           **/pyproject.toml
+          .pre-commit-config.yaml
 
     - name: Get Packages
       # Briefcase will build and package itself in a previous step in its CI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,13 @@ env:
 
 jobs:
   pre-commit:
-    name: Pre-commit checks
+    name: Pre-commit Checks
     uses: ./.github/workflows/pre-commit-run.yml
     with:
-      pre-commit-source: "pre-commit"
+      pre-commit-source: pre-commit
 
   test-docs-build-verify:
-    name: Test Verify Docs Build
+    name: Verify Docs Build Check
     needs: pre-commit
     # inheriting secrets does not work for forked repos
     if: ${{ github.event.pull_request.head.repo.owner.login == 'beeware' }}
@@ -44,7 +44,7 @@ jobs:
           version: "v0.3.1"
 
   test-install-briefcase:
-    name: Test Install Briefcase
+    name: Install Briefcase
     needs: pre-commit
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -112,13 +112,18 @@ jobs:
           testing-pr-ref: "v40.0.5"
           expected: "main"
     steps:
-    - name: Checkout .github repo
+    - name: Checkout beeware/.github
       uses: actions/checkout@v4.1.1
 
     - name: Set up Python
       uses: actions/setup-python@v4.7.1
       with:
-        python-version: "3.X"
+        python-version: 3.X
+        cache: pip
+        cache-dependency-path: |
+          **/setup.cfg
+          **/pyproject.toml
+          .pre-commit-config.yaml
 
     - name: Install Briefcase
       id: briefcase
@@ -130,7 +135,7 @@ jobs:
         testing-pr-ref: ${{ matrix.testing-pr-ref }}
         testing-ref-name: ${{ matrix.testing-ref-name }}
 
-    - name: Test Briefcase @ ${{ matrix.test-case }}
+    - name: Briefcase @ ${{ matrix.test-case }}
       run: |
         if [[ "${{ matrix.expected }}" != "${{ steps.briefcase.outputs.installed-version }}" ]]; then
           echo "installed-version: ${{ steps.briefcase.outputs.installed-version }}"
@@ -140,7 +145,7 @@ jobs:
         fi
 
   test-pre-commit-run:
-    name: Test Pre-commit
+    name: Pre-commit
     needs: pre-commit
     uses: ./.github/workflows/pre-commit-run.yml
     with:
@@ -160,7 +165,7 @@ jobs:
           pre-commit-source: "./core[dev]"
 
   test-package-python:
-    name: Test Python Package Create
+    name: Create Package
     needs: pre-commit
     uses: ./.github/workflows/python-package-create.yml
     with:
@@ -184,7 +189,7 @@ jobs:
           build-subdir: "core"
 
   test-create-apps-briefcase:
-    name: Test Create Apps
+    name: Create Apps
     needs: [ pre-commit, test-package-python ]
     uses: ./.github/workflows/app-create-verify.yml
     with:
@@ -198,7 +203,7 @@ jobs:
         runner-os: [ "macos-latest", "windows-latest", "ubuntu-22.04" ]
 
   test-verify-apps-briefcase:
-    name: Test Verify Apps
+    name: Verify Briefcase
     needs: [ pre-commit, test-package-python ]
     uses: ./.github/workflows/app-build-verify.yml
     with:
@@ -213,7 +218,7 @@ jobs:
         runner-os: [ "macos-latest", "windows-latest", "ubuntu-22.04" ]
 
   test-verify-apps-briefcase-template:
-    name: Test Briefcase Template Verify Apps
+    name: Verify Briefcase Template
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:
@@ -229,7 +234,7 @@ jobs:
         runner-os: [ "macos-latest", "windows-latest", "ubuntu-latest" ]
 
   test-verify-apps-android-templates:
-    name: Test Verify Android App
+    name: Verify Android
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:
@@ -245,7 +250,7 @@ jobs:
         runner-os: [ "macos-latest", "windows-latest", "ubuntu-latest" ]
 
   test-verify-apps-iOS-templates:
-    name: Test Verify iOS App
+    name: Verify iOS
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:
@@ -257,7 +262,7 @@ jobs:
       framework: toga
 
   test-verify-apps-linux-system-templates:
-    name: Test Verify Linux System App
+    name: Verify Linux System
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:
@@ -275,7 +280,7 @@ jobs:
         framework: [ "toga", "ppb" ]
 
   test-verify-apps-appimage-templates:
-    name: Test Verify AppImage App
+    name: Verify AppImage
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:
@@ -287,7 +292,7 @@ jobs:
       framework: toga
 
   test-verify-apps-flatpak-templates:
-    name: Test Verify Flatpak App
+    name: Verify Flatpak
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:
@@ -303,7 +308,7 @@ jobs:
         framework: [ "toga", "pygame" ]
 
   test-verify-apps-macOS-templates:
-    name: Test Verify macOS App
+    name: Verify macOS
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:
@@ -320,7 +325,7 @@ jobs:
         framework: [ "toga", "ppb" ]
 
   test-verify-apps-web-templates:
-    name: Test Verify Web App
+    name: Verify Web
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:
@@ -332,7 +337,7 @@ jobs:
       framework: toga
 
   test-verify-apps-windows-templates:
-    name: Test Verify Windows App
+    name: Verify Windows
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,6 @@ jobs:
       python-version: "3.10"  # must match system python for ubuntu version
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
-      briefcase-template-source: ${{ github.workspace }}
     strategy:
       fail-fast: false
       matrix:
@@ -227,7 +226,6 @@ jobs:
       repository: beeware/briefcase-template
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
-      briefcase-template-source: ${{ github.workspace }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,7 @@ jobs:
       python-version: "3.10"  # must match system python for ubuntu version
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
+      briefcase-template-source: ${{ github.workspace }}
     strategy:
       fail-fast: false
       matrix:
@@ -224,9 +225,9 @@ jobs:
     with:
       python-version: "3.11"
       repository: beeware/briefcase-template
-      briefcase-template-source: "../../"
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
+      briefcase-template-source: ${{ github.workspace }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       pre-commit-source: pre-commit
 
   test-docs-build-verify:
-    name: Verify Docs Build Check
+    name: Verify Docs Build
     needs: pre-commit
     # inheriting secrets does not work for forked repos
     if: ${{ github.event.pull_request.head.repo.owner.login == 'beeware' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,12 +183,26 @@ jobs:
           dist-path: "*/dist/*"
           build-subdir: "core"
 
+  test-create-apps-briefcase:
+    name: Test Create Apps
+    needs: [ pre-commit, test-package-python ]
+    uses: ./.github/workflows/app-create-verify.yml
+    with:
+      python-version: "3.10"  # must match system python for ubuntu version
+      runner-os: ${{ matrix.runner-os }}
+      framework: ${{ matrix.framework }}
+    strategy:
+      fail-fast: false
+      matrix:
+        framework: [ "toga", "pyside6" ]
+        runner-os: [ "macos-latest", "windows-latest", "ubuntu-22.04" ]
+
   test-verify-apps-briefcase:
     name: Test Verify Apps
-    needs: [pre-commit, test-package-python]
+    needs: [ pre-commit, test-package-python ]
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      python-version: "3.11"
+      python-version: "3.10"  # must match system python for ubuntu version
       repository: beeware/briefcase
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
@@ -196,7 +210,7 @@ jobs:
       fail-fast: false
       matrix:
         framework: [ "toga", "ppb" ]
-        runner-os: [ "macos-latest", "windows-latest", "ubuntu-latest" ]
+        runner-os: [ "macos-latest", "windows-latest", "ubuntu-22.04" ]
 
   test-verify-apps-briefcase-template:
     name: Test Briefcase Template Verify Apps
@@ -258,7 +272,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        framework: [ "toga", "ppb", "pyside2" ]
+        framework: [ "toga", "ppb" ]
 
   test-verify-apps-appimage-templates:
     name: Test Verify AppImage App

--- a/.github/workflows/pre-commit-run.yml
+++ b/.github/workflows/pre-commit-run.yml
@@ -44,6 +44,11 @@ jobs:
       uses: actions/setup-python@v4.7.1
       with:
         python-version: ${{ inputs.python-version }}
+        cache: pip
+        cache-dependency-path: |
+          **/setup.cfg
+          **/pyproject.toml
+          .pre-commit-config.yaml
 
     - name: Cache pre-commit
       uses: actions/cache@v3.3.2

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -73,6 +73,10 @@ jobs:
         uses: actions/setup-python@v4.7.1
         with:
           python-version: 3.X
+          cache: pip
+          cache-dependency-path: |
+            **/setup.cfg
+            **/pyproject.toml
 
       - name: Install pre-commit
         run: python -m pip install ${{ inputs.pre-commit-source || 'pre-commit' }}

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -77,6 +77,7 @@ jobs:
           cache-dependency-path: |
             **/setup.cfg
             **/pyproject.toml
+            .pre-commit-config.yaml
 
       - name: Install pre-commit
         run: python -m pip install ${{ inputs.pre-commit-source || 'pre-commit' }}

--- a/.github/workflows/python-package-create.yml
+++ b/.github/workflows/python-package-create.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/setup-python@v4.7.1
         with:
           python-version: ${{ inputs.python-version }}
-          cache: "pip"
+          cache: pip
           cache-dependency-path: |
             **/setup.cfg
             **/pyproject.toml

--- a/.github/workflows/towncrier-run.yml
+++ b/.github/workflows/towncrier-run.yml
@@ -55,7 +55,7 @@ jobs:
       uses: actions/setup-python@v4.7.1
       with:
         python-version: ${{ inputs.python-version }}
-        cache: "pip"
+        cache: pip
         cache-dependency-path: |
           **/setup.cfg
           **/pyproject.toml


### PR DESCRIPTION
## Changes
- Introduces a composite action to create a Briefcase project based on a GUI toolkit and optional template
- Introduces a workflow, `app-create-verify.yml`, for repos to run in CI that have impacts on project creation
  - Notably, `beeware/briefcase-template` and `beeware/briefcase` should implement this

BRIEFCASE_REPO: https://github.com/rmartin16/briefcase
BRIEFCASE_REF: gui-plugin-support
BRIEFCASE_TEMPLATE_REPO: https://github.com/rmartin16/briefcase-template
BRIEFCASE_TEMPLATE_REF: gui-plugin-support

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
