### PR TITLE
Ensure rolled out templates pass Black

### DIFF
--- a/.github/workflows/app-create-verify.yml
+++ b/.github/workflows/app-create-verify.yml
@@ -36,8 +36,8 @@ env:
   FORCE_COLOR: "1"
 
 jobs:
-  verify-app:
-    name: Verify App Create
+  verify-project:
+    name: Verify Project
     runs-on: ${{ inputs.runner-os }}
     steps:
 
@@ -56,7 +56,9 @@ jobs:
     - name: Checkout beeware/briefcase-template
       uses: actions/checkout@v4.1.1
       with:
-        repository: beeware/briefcase-template
+#        repository: beeware/briefcase-template  # TODO:PR: uncomment
+        repository: rmartin16/briefcase-template  # TODO:PR: remove me
+        ref: black  # TODO:PR: remove me
         path: briefcase-template
 
     - name: Package Name
@@ -98,7 +100,7 @@ jobs:
       if: endsWith(github.repository, 'briefcase-template')
       run: echo "path=${{ github.workspace }}" | tee -a ${GITHUB_OUTPUT}
 
-    - name: Create Briefcase project
+    - name: Create Briefcase Project
       id: create
       uses: ./beeware-.github/.github/actions/app-create
       with:
@@ -109,6 +111,10 @@ jobs:
     - name: Run Flake8
       working-directory: ${{ steps.create.outputs.project-path }}
       run: flake8 --select=E
+
+    - name: Run Black
+      working-directory: ${{ steps.create.outputs.project-path }}
+      run: black --check --diff --color src/
 
     - name: Validate pyproject.toml
       working-directory: ${{ steps.create.outputs.project-path }}

--- a/.github/workflows/app-create-verify.yml
+++ b/.github/workflows/app-create-verify.yml
@@ -56,9 +56,7 @@ jobs:
     - name: Checkout beeware/briefcase-template
       uses: actions/checkout@v4.1.1
       with:
-#        repository: beeware/briefcase-template  # TODO:PR: uncomment
-        repository: rmartin16/briefcase-template  # TODO:PR: remove me
-        ref: black  # TODO:PR: remove me
+        repository: beeware/briefcase-template
         path: briefcase-template
 
     - name: Package Name

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,8 +188,8 @@ jobs:
           dist-path: "*/dist/*"
           build-subdir: "core"
 
-  test-create-apps-briefcase:
-    name: Create Apps
+  test-verify-projects-briefcase:
+    name: Verify Project
     needs: [ pre-commit, test-package-python ]
     uses: ./.github/workflows/app-create-verify.yml
     with:


### PR DESCRIPTION
## Changes
- Along with passing flake8, templates must pass Black as well
- I also changed most wordings of "app create" to "project create" to avoid confusion with `briefcase create` 
  - Also renaming the action from `app-create` to `project-create` creates whole other round of cross-dependent PRs....so i didn't do this but I think that's less important than the display in GitHub Actions UI listing all the workflow jobs having a more obvious name
- Demonstration: CI [passing](https://github.com/beeware/.github/actions/runs/6946730301/job/18899023268#step:14:13) with briefcase-template changes

## Notes
- Since we have to maintain the source code for new apps for users in strings, I figured it might be a good idea to ensure that source is consistent and pretty.

## Merging
- These PRs are independent and should be merged first:
  - https://github.com/beeware/briefcase-template/pull/85
  - https://github.com/beeware/briefcase/pull/1548
- (There was some briefcase template overrides here; they were removed once the first two PRs were merged)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct