### PR TITLE
Upgrade `upload-artifact` and `download-artifact` actions to v4

### DIFF
--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -120,7 +120,7 @@ jobs:
     - name: Get Briefcase Packages
       # Briefcase will build and package itself in a previous step in its CI
       if: endsWith(inputs.repository, 'briefcase')
-      uses: actions/download-artifact@v3.0.2
+      uses: actions/download-artifact@v4.1.0
       with:
         name: packages-briefcase
         path: dist
@@ -382,7 +382,7 @@ jobs:
         briefcase package web static
 
     - name: Upload Failure Logs
-      uses: actions/upload-artifact@v3.1.3
+      uses: actions/upload-artifact@v4.0.0
       if: failure()
       with:
         name: build-failure-logs-${{ inputs.runner-os }}-${{ inputs.framework }}-${{ inputs.python-version }}-${{ inputs.target-platform }}-${{ inputs.target-format }}

--- a/.github/workflows/app-create-verify.yml
+++ b/.github/workflows/app-create-verify.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Get Briefcase Package
       # Briefcase will build and package itself in a previous step in its CI
       if: endsWith(github.repository, 'briefcase')
-      uses: actions/download-artifact@v3.0.2
+      uses: actions/download-artifact@v4.1.0
       with:
         name: packages-briefcase
         path: dist
@@ -121,8 +121,8 @@ jobs:
         assert pyproject_toml.is_file()
         pprint(toml.load(pyproject_toml))
 
-    - name: Upload failure logs
-      uses: actions/upload-artifact@v3.1.3
+    - name: Upload Failure Logs
+      uses: actions/upload-artifact@v4.0.0
       if: failure()
       with:
         name: build-failure-logs-${{ inputs.runner-os }}-${{ inputs.framework }}-${{ inputs.python-version }}

--- a/.github/workflows/python-package-create.yml
+++ b/.github/workflows/python-package-create.yml
@@ -37,7 +37,13 @@ on:
         type: string
     outputs:
       artifact-name:
-        description: "Name of the uploaded artifact; use for artifact retrieval."
+        description: >
+          Name of the uploaded artifact; use for artifact retrieval.
+          Note that if a `build-subdirectory` is specified, this value will be the "base" of the artifact name.
+          For instance, if the `core` subdirectory of Toga is being built, then this value will be `packages-toga`
+          but the name of the uploaded artifact will be `packages-toga-core`.
+          Therefore, when a `build-subdirectory` is used with this workflow, the `pattern` input for the
+          `actions\download-artifact` should be used to specify `${ needs.package.outputs.artifact-name }-*`.
         value: ${{ jobs.package.outputs.artifact-name }}
 
 env:
@@ -51,7 +57,7 @@ jobs:
       artifact-name: packages-${{ steps.package.outputs.name }}
     steps:
 
-      - name: Determine Package name
+      - name: Determine Package Name
         id: package
         run: echo "name=$(basename '${{ inputs.repository }}')" >> ${GITHUB_OUTPUT}
 
@@ -76,17 +82,17 @@ jobs:
       - name: Install tox
         run: python -m pip install ${{ inputs.tox-source }}
 
-      - name: Build wheels
+      - name: Build Wheels
         if: inputs.build-subdirectory == ''
         run: tox -e package${{ inputs.tox-factors }}
 
-      - name: Build wheels from subdirectory
+      - name: Build Wheels from Subdirectory
         if: inputs.build-subdirectory != ''
         run: tox -e package${{ inputs.tox-factors }} -- ${{ inputs.build-subdirectory }}
 
       - name: Upload Package
-        uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v4.0.0
         with:
-          name: packages-${{ steps.package.outputs.name }}
+          name: packages-${{ steps.package.outputs.name }}${{ inputs.build-subdirectory && format('-{0}', inputs.build-subdirectory) || '' }}
           path: ${{ inputs.distribution-path }}
           if-no-files-found: error


### PR DESCRIPTION
## Changes
- Fixes #77
- The `upload-artifact` and `download-artifact` actions can be upgraded without other changes since they're already only dealing with unique artifacts
- 🚨 BREAKING 🚨
  - This change affect the `python-package-create` workflow which is used by other repos to create an artifact containing the Python package created for repo.
  - Due to the underlying re-implementation of `upload-artifact` and `download-artifact`, artifacts created with v3 cannot be downloaded with v4....and vice versa.
  - Therefore, this change must be merged in tandem with these PRs:
    - https://github.com/beeware/briefcase/pull/1589
    - https://github.com/beeware/toga/pull/2318
    - https://github.com/beeware/rubicon-objc/pull/397
    - https://github.com/beeware/travertino/pull/124
    - https://github.com/beeware/toga-chart/pull/78

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct