### PR TITLE
Run `setup-python` if the requested Python is not the System Python

### DIFF
--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -107,7 +107,7 @@ jobs:
 
     - name: Set Up Python
       # Linux System apps requires python is System Python to run the app
-      if: ${{ !startsWith(inputs.runner-os, 'ubuntu') }}
+      if: ${{ !startsWith(inputs.runner-os, 'ubuntu') || !startsWith(inputs.python-version, steps.config.outputs.system-python-version) }}
       uses: actions/setup-python@v5.0.0
       with:
         python-version: ${{ inputs.python-version }}


### PR DESCRIPTION
## Changes
- Linux System builds require the app is built with the System Python; that is, the Python from `setup-python` cannot be used if you also want to run the created app
- Since the Linux System build is only actually run if the requested Python is the same as the System Python, run `setup-python` if they are different

Demo for Briefcase: https://github.com/beeware/briefcase/actions/runs/7454601543/job/20282336558
Demo for AppImage: https://github.com/beeware/briefcase-linux-appimage-template/actions/runs/7454506398/job/20281949158#step:7:20

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct