### PR TITLE
Delete Docker images to free up disk space

### DIFF
--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -290,6 +290,11 @@ jobs:
         docker run --volume $(pwd)/dist:/dist opensuse/tumbleweed \
           sh -c "zypper --non-interactive --no-gpg-checks install /dist/*-0.0.1-1.x86_64.rpm"
 
+    - name: Delete Docker Images
+      # the GitHub runners come with limited disk space; these images take ~8GB
+      if: startsWith(inputs.runner-os, 'ubuntu')
+      run: docker system prune --all --force
+
     - name: Build AppImage Project
       # 2023-09-11 AppImage dropped to "best effort" support.
       #


### PR DESCRIPTION
- The GitHub runners have limited disk space and creating Docker images occupies ~8GB of disk space. To ensure later tests, such as Android, can run, this deletes all the Docker images.
- RE: https://github.com/beeware/briefcase/pull/1630#issuecomment-1925456651

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
