### PR TITLE
Explicitly declare the BRUTUS_PAT_TOKEN secret.

### DIFF
--- a/.github/workflows/dependabot-changenote.yml
+++ b/.github/workflows/dependabot-changenote.yml
@@ -2,6 +2,9 @@ name: Dependabot Change Note
 
 on:
   workflow_call:
+    secrets:
+      BRUTUS_PAT_TOKEN:
+        required: true
 
 permissions:
   pull-requests: write

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -18,6 +18,9 @@ on:
         description: "Defaults 'true' to create a misc changenote in the './changes' directory."
         default: true
         type: boolean
+    secrets:
+      BRUTUS_PAT_TOKEN:
+        required: true
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
Explicitly declares the BRUTUS_PAT_TOKEN secret, so that the workflow can be used outside the beeware organization.

Secrets [aren't shared with reusable workflows](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow) if the workflow is defined in a different organisation. To allow secrets to be used, the secret must be [explicitly declared as part of the `workflow_call` definition](https://docs.github.com/en/actions/using-workflows/reusing-workflows#example-reusable-workflow).

This was discovered as part of adding pre-commit-update to the [dmgbuild repo](https://github.com/dmgbuild/mac_alias/actions/runs/7777844611)

From what I can tell, this should have no impact for workflows in the same organization - for those workflows `secrets: inherit` implicitly passes through all repo, environment and organization secrets. 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
