### PR TITLE
print `bash` commands as they are executed

### DIFF
--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -45,7 +45,7 @@ on:
 
 defaults:
   run:
-    shell: bash
+    shell: bash --noprofile --norc -x -e -o pipefail {0}
 
 env:
   FORCE_COLOR: "1"


### PR DESCRIPTION
## Changes
- Use `bash --noprofile --norc -x -e -o pipefail {0}` as the shell for all `run` actions
- I often feel lost in the workflow output; this helps keep track of where you are in the list of commands

## Notes
- My primary concern with this is we no longer inherit the list of `bash` options that GitHub uses by default.
- That said, I think these options are quite stable and unlikely to meaningfully change over time.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
