### PR TITLE
Use ghcr.io for Docker image caching

### DIFF
--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -55,6 +55,9 @@ jobs:
     name: Verify App Build
     runs-on: ${{ inputs.runner-os }}
     timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
     env:
       SDL_AUDIODRIVER: dummy  # disable audio for SDL
       TOGA_SYSTEM_REQUIRES: libthai-dev libegl1 libcairo2-dev libgirepository1.0-dev gir1.2-gtk-3.0
@@ -240,15 +243,67 @@ jobs:
 
         bash -c "sudo apt -y install --dry-run ./dist/*_0.0.1-1~ubuntu-*_amd64.deb"
 
+    - name: Log in to GitHub Container Registry
+      if: >
+        startsWith(inputs.runner-os, 'ubuntu')
+        && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
+        && contains(fromJSON('["", "system", "appimage"]'), inputs.target-format)
+      uses: docker/login-action@v3.0.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set up Docker Buildx
+      if: >
+        startsWith(inputs.runner-os, 'ubuntu')
+        && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
+        && contains(fromJSON('["", "system", "appimage"]'), inputs.target-format)
+      uses: docker/setup-buildx-action@v3.0.0
+
+    - name: Docker Caching Configuration
+      id: docker
+      if: >
+        startsWith(inputs.runner-os, 'ubuntu')
+        && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
+        && contains(fromJSON('["", "system", "appimage"]'), inputs.target-format)
+      env:
+        GITHUB_REF_NAME: ${{ github.ref_name }}
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+      run: |
+        PKG_NAME="beeware-ci"
+        REGISTRY_PKG="ghcr.io/$(cut -d/ -f1 <<< "${{ github.repository }}")/${PKG_NAME}"
+        CURRENT_REF="$(sed 's|[^a-z0-9_-]|_|g' <<< "${GITHUB_REF_NAME,,}")"
+        DEFAULT_REF="$(sed 's|[^a-z0-9_-]|_|g' <<< "${DEFAULT_BRANCH,,}")"
+
+        # include all layers, minimize compression time, and ignore package upload issues
+        CACHE_TO_OPTS="mode=max,compression-level=0,ignore-error=true"
+
+        BUILDX_OPTIONS=(
+          # attempt to push to BeeWare's package
+          --Xdocker-build=--cache-to=type=registry,ref=${REGISTRY_PKG}:__PKG_TAG__-${CURRENT_REF},${CACHE_TO_OPTS}
+          # retrieve the cache using the current branch, falling back to the default branch
+          --Xdocker-build=--cache-from=type=registry,ref=${REGISTRY_PKG}:__PKG_TAG__-${CURRENT_REF}
+          --Xdocker-build=--cache-from=type=registry,ref=${REGISTRY_PKG}:__PKG_TAG__-${DEFAULT_REF}
+        )
+        echo "DOCKER_BUILDX_OPTIONS=${BUILDX_OPTIONS[@]}" | tee -a ${GITHUB_ENV}
+
+        # Tag format: app-build-<year>-<month>-<framework>-<python-version>-<format>-<format-differentiators>-<branch>
+        # For example: app-build-24-02-toga-3.11-system-debian-bookworm-main
+        echo "tag-base=app-build-$(date +%Y-%m)-${{ inputs.framework }}-${{ inputs.python-version }}" | tee -a ${GITHUB_OUTPUT}
+
     - name: Build Linux System Project (Debian, Dockerized)
       if: >
         startsWith(inputs.runner-os, 'ubuntu')
         && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
         && contains(fromJSON('["", "system"]'), inputs.target-format)
       working-directory: ${{ steps.create.outputs.project-path }}
+      env:
+        PKG_TAG: ${{ steps.docker.outputs.tag-base }}-system-debian-bookworm
       run: |
         briefcase create linux system --target debian:bookworm \
-          ${{ steps.output-format.outputs.template-override }}
+          ${{ steps.output-format.outputs.template-override }} \
+          ${DOCKER_BUILDX_OPTIONS//__PKG_TAG__/${PKG_TAG}}
         briefcase build linux system --target debian:bookworm
         xvfb-run briefcase run linux system --target debian:bookworm
         briefcase package linux system --target debian:bookworm --adhoc-sign
@@ -262,9 +317,12 @@ jobs:
         && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
         && contains(fromJSON('["", "system"]'), inputs.target-format)
       working-directory: ${{ steps.create.outputs.project-path }}
+      env:
+        PKG_TAG: ${{ steps.docker.outputs.tag-base }}-system-fedora-39
       run: |
         briefcase create linux system --target fedora:39 \
-          ${{ steps.output-format.outputs.template-override }}
+          ${{ steps.output-format.outputs.template-override }} \
+          ${DOCKER_BUILDX_OPTIONS//__PKG_TAG__/${PKG_TAG}}
         briefcase build linux system --target fedora:39
         xvfb-run briefcase run linux system --target fedora:39
         briefcase package linux system --target fedora:39 --adhoc-sign
@@ -278,9 +336,12 @@ jobs:
         && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
         && contains(fromJSON('["", "system"]'), inputs.target-format)
       working-directory: ${{ steps.create.outputs.project-path }}
+      env:
+        PKG_TAG: ${{ steps.docker.outputs.tag-base }}-system-arch
       run: |
         briefcase create linux system --target archlinux:latest \
-          ${{ steps.output-format.outputs.template-override }}
+          ${{ steps.output-format.outputs.template-override }} \
+          ${DOCKER_BUILDX_OPTIONS//__PKG_TAG__/${PKG_TAG}}
         briefcase build linux system --target archlinux:latest
         xvfb-run briefcase run linux system --target archlinux:latest
         briefcase package linux system --target archlinux:latest --adhoc-sign
@@ -294,20 +355,18 @@ jobs:
         && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
         && contains(fromJSON('["", "system"]'), inputs.target-format)
       working-directory: ${{ steps.create.outputs.project-path }}
+      env:
+        PKG_TAG: ${{ steps.docker.outputs.tag-base }}-system-opensuse
       run: |
         briefcase create linux system --target opensuse/tumbleweed:latest \
-          ${{ steps.output-format.outputs.template-override }}
+          ${{ steps.output-format.outputs.template-override }} \
+          ${DOCKER_BUILDX_OPTIONS//__PKG_TAG__/${PKG_TAG}}
         briefcase build linux system --target opensuse/tumbleweed:latest
         xvfb-run briefcase run linux system --target opensuse/tumbleweed:latest
         briefcase package linux system --target opensuse/tumbleweed:latest --adhoc-sign
 
         docker run --volume $(pwd)/dist:/dist opensuse/tumbleweed \
           sh -c "zypper --non-interactive --no-gpg-checks install --dry-run /dist/*-0.0.1-1.x86_64.rpm"
-
-    - name: Delete Docker Images
-      # the GitHub runners come with limited disk space; these images take ~8GB
-      if: startsWith(inputs.runner-os, 'ubuntu')
-      run: docker system prune --all --force
 
     - name: Build AppImage Project
       # 2023-09-11 AppImage dropped to "best effort" support.
@@ -328,6 +387,8 @@ jobs:
         && contains(fromJSON('["Linux"]'), inputs.target-platform)
         && contains(fromJSON('["AppImage"]'), inputs.target-format)
       working-directory: ${{ steps.create.outputs.project-path }}
+      env:
+        PKG_TAG: ${{ steps.docker.outputs.tag-base }}-appimage
       run: |
         PACKAGES="libfuse2"
         case "$(tr '[:upper:]' '[:lower:]' <<< '${{ inputs.framework }}')" in
@@ -346,10 +407,18 @@ jobs:
 
         briefcase create linux AppImage \
           ${{ steps.output-format.outputs.template-override }} \
-          ${CONFIG_OVERRIDE_REQUIRES}
+          ${CONFIG_OVERRIDE_REQUIRES} \
+          ${DOCKER_BUILDX_OPTIONS//__PKG_TAG__/${PKG_TAG}}
         briefcase build linux AppImage
         xvfb-run briefcase run linux AppImage
         briefcase package linux AppImage --adhoc-sign
+
+    - name: Delete Docker Images
+      # the GitHub runners come with limited disk space; these images take ~8GB
+      if: startsWith(inputs.runner-os, 'ubuntu')
+      run: |
+        docker system prune --all --force
+        docker buildx prune --all --force
 
     - name: Build Flatpak Project
       if: >


### PR DESCRIPTION
## Changes
- Use a ghcr.io package called "beeware-ci" to cache Docker image builds
- This implementation is inspired by how [caching is managed](https://github.com/indygreg/python-build-standalone/blob/94de081efb139cc48a0cdb9c891374ad9b2cdfe2/.github/workflows/linux.yml#L94) in the python-build-standalone project....so, there's at least _some_ precedent for this approach
- Images for different Briefcase builds are managed by tags on the package
  - This allows CI to manage many independent images while only creating one package in ghcr.io
  - Example `beeware-ci` package: https://github.com/rmartin16/.github-beeware-test/pkgs/container/beeware-ci
- Caching strategy
  - The cache is pulled in from one of three places in this precedence:
    - The package from BeeWare org using the branch for the event
    - The package from BeeWare org using the `main` branch
  - The cache is pushed to the `beeware-ci` package for the BeeWare org
    - So, for a PR, this will be for a tag using the branch name
    - For a merge in to `main`, that will be a tag for `main` branch
    - This caching will likely fail except for the `main` branch because the `GITHUB_TOKEN` for PRs doesn't allow for writing to packages
    - However, that should be fine because the cache can still be pulled using the `main` tag
- Closes #98

## Notes
- Dependent on https://github.com/beeware/briefcase/pull/1661

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct