### PR TITLE
Deprecate PySide6 AppImage testing.

### DIFF
--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -378,7 +378,9 @@ jobs:
       # push) is fundamentally incompatible with using an old base image. As of today,
       # it's impossible to install Toga on *any* manylinux image (
       # https://gitlab.gnome.org/GNOME/pygobject/-/issues/590); PySide2 can't be
-      # installed on any *supported* manylinux image, and PySide6 only works on 2_28.
+      # installed on any *supported* manylinux image; PySide6 only publishes 2_28 wheels,
+      # but even then, it segfaults when the AppImage starts.
+      #
       # Even when the install *does* work, there are so many incompatibility and
       # binary dependency issues that it's just not worth the oxygen to keep this thing
       # alive.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,7 +360,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        framework: [ toga, pyside6, pygame, console ]
+        # 2024-07-11 (beeware/briefcase#1908): pyside6 segfaults on AppImage start.
+        framework: [ toga, pygame, console ]
 
   test-verify-apps-flatpak-templates:
     name: Verify Flatpak


### PR DESCRIPTION
Fixes beeware/briefcase#1908.

AppImage support is explicitly best-effort at this point; since PySide6 support is causing problems, it gets put into the "ignored" pile.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
