### PR TITLE
Enable allow-prereleases on all Python installs.

### DIFF
--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -223,7 +223,7 @@ jobs:
     - name: Build Linux System Project (Ubuntu, local)
       if: >
         startsWith(inputs.runner-os, 'ubuntu')
-        && inputs.python-version == "system"
+        && inputs.python-version == 'system'
         && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
         && contains(fromJSON('["", "system"]'), inputs.target-format)
       working-directory: ${{ steps.create.outputs.project-path }}

--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -111,10 +111,14 @@ jobs:
         path: ${{ steps.config.outputs.briefcase-data-dir }}
 
     - name: Set Up Python
-      if: ${{ inputs.python-version != 'system' }}
+      # On Linux, we can use the system python as-is. On macOS/Windows, install
+      # a Python that matches the version provided as a system default. This is
+      # to avoid issues with trying to install packages into homebrew's python
+      # without requiring sudo.
+      if: ${{ !startsWith(inputs.runner-os, 'ubuntu') || inputs.python-version != 'system' }}
       uses: actions/setup-python@v5.2.0
       with:
-        python-version: ${{ inputs.python-version }}
+        python-version: ${{ inputs.python-version == 'system' && steps.config.system-python-version || inputs.python-version }}
         allow-prereleases: true
         cache: pip
         cache-dependency-path: |

--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -82,9 +82,6 @@ jobs:
         fi
         echo "cache-key=$(date +%Y-%m)|${CACHE_KEY}" | tee -a ${GITHUB_OUTPUT}
 
-        SYSTEM_PYTHON_VER=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
-        echo "system-python-version=${SYSTEM_PYTHON_VER}" | tee -a ${GITHUB_OUTPUT}
-
     - name: Checkout ${{ inputs.repository }}
       uses: actions/checkout@v4.2.0
       with:

--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -114,7 +114,7 @@ jobs:
       if: ${{ !startsWith(inputs.runner-os, 'ubuntu') || inputs.python-version != 'system' }}
       uses: actions/setup-python@v5.2.0
       with:
-        python-version: ${{ inputs.python-version }}
+        python-version: ${{ inputs.python-version || '3.x' }}
         allow-prereleases: true
         cache: pip
         cache-dependency-path: |

--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -10,7 +10,7 @@ on:
     inputs:
       python-version:
         description: "Python version to use; defaults to latest Python release."
-        default: "3.X"
+        default: "3.x"
         type: string
       runner-os:
         description: "The OS to use to build the App; must be a fully qualified GitHub runner OS, e.g. ubuntu-latest."
@@ -116,6 +116,7 @@ jobs:
       uses: actions/setup-python@v5.2.0
       with:
         python-version: ${{ inputs.python-version }}
+        allow-prereleases: true
         cache: pip
         cache-dependency-path: |
           **/setup.cfg

--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -111,8 +111,7 @@ jobs:
         path: ${{ steps.config.outputs.briefcase-data-dir }}
 
     - name: Set Up Python
-      # Linux System apps can only use the system Python to run the app
-      if: ${{ !startsWith(inputs.runner-os, 'ubuntu') || inputs.python-version != 'system' }}
+      if: ${{ inputs.python-version != 'system' }}
       uses: actions/setup-python@v5.2.0
       with:
         python-version: ${{ inputs.python-version }}

--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -118,7 +118,7 @@ jobs:
       if: ${{ !startsWith(inputs.runner-os, 'ubuntu') || inputs.python-version != 'system' }}
       uses: actions/setup-python@v5.2.0
       with:
-        python-version: ${{ inputs.python-version == 'system' && steps.config.system-python-version || inputs.python-version }}
+        python-version: ${{ inputs.python-version == 'system' && steps.config.outputs.system-python-version || inputs.python-version }}
         allow-prereleases: true
         cache: pip
         cache-dependency-path: |

--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -111,14 +111,13 @@ jobs:
         path: ${{ steps.config.outputs.briefcase-data-dir }}
 
     - name: Set Up Python
-      # On Linux, we can use the system python as-is. On macOS/Windows, install
-      # a Python that matches the version provided as a system default. This is
-      # to avoid issues with trying to install packages into homebrew's python
-      # without requiring sudo.
+      # On Linux, accept "system" as a proxy for "don't install Python"; this will
+      # fall back to the system-provided Python package. Providing "system" as a value
+      # on macOS or Windows will cause an error.
       if: ${{ !startsWith(inputs.runner-os, 'ubuntu') || inputs.python-version != 'system' }}
       uses: actions/setup-python@v5.2.0
       with:
-        python-version: ${{ inputs.python-version == 'system' && steps.config.outputs.system-python-version || inputs.python-version }}
+        python-version: ${{ inputs.python-version }}
         allow-prereleases: true
         cache: pip
         cache-dependency-path: |

--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -111,8 +111,8 @@ jobs:
         path: ${{ steps.config.outputs.briefcase-data-dir }}
 
     - name: Set Up Python
-      # Linux System apps requires python is System Python to run the app
-      if: ${{ !startsWith(inputs.runner-os, 'ubuntu') || !startsWith(inputs.python-version, steps.config.outputs.system-python-version) }}
+      # Linux System apps can only use the system Python to run the app
+      if: ${{ !startsWith(inputs.runner-os, 'ubuntu') || inputs.python-version != 'system' }}
       uses: actions/setup-python@v5.2.0
       with:
         python-version: ${{ inputs.python-version }}
@@ -223,7 +223,7 @@ jobs:
     - name: Build Linux System Project (Ubuntu, local)
       if: >
         startsWith(inputs.runner-os, 'ubuntu')
-        && startsWith(inputs.python-version, steps.config.outputs.system-python-version)
+        && inputs.python-version == "system"
         && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
         && contains(fromJSON('["", "system"]'), inputs.target-format)
       working-directory: ${{ steps.create.outputs.project-path }}

--- a/.github/workflows/app-create-verify.yml
+++ b/.github/workflows/app-create-verify.yml
@@ -76,7 +76,7 @@ jobs:
       # Always set up a Python, so that dependencies can be installed without sudo access
       uses: actions/setup-python@v5.2.0
       with:
-        python-version: ${{ inputs.python-version == 'system' && steps.config.system-python-version || inputs.python-version }}
+        python-version: ${{ inputs.python-version == 'system' && steps.config.outputs.system-python-version || inputs.python-version }}
         cache: pip
         allow-prereleases: true
         cache-dependency-path: |

--- a/.github/workflows/app-create-verify.yml
+++ b/.github/workflows/app-create-verify.yml
@@ -73,10 +73,13 @@ jobs:
         path: briefcase-template
 
     - name: Set up Python
-      # Always set up a Python, so that dependencies can be installed without sudo access
+      # On Linux, accept a value of "system", which will install a version of
+      # Python matching the system version. We can't use the actual system
+      # install because we need to install dependencies, which would either
+      # require the use of sudo, or extra workarounds for user-space packages.
       uses: actions/setup-python@v5.2.0
       with:
-        python-version: ${{ inputs.python-version == 'system' && steps.config.outputs.system-python-version || inputs.python-version }}
+        python-version: ${{ startsWith(inputs.runner-os, 'ubuntu') && inputs.python-version == 'system' && steps.config.outputs.system-python-version || inputs.python-version }}
         cache: pip
         allow-prereleases: true
         cache-dependency-path: |

--- a/.github/workflows/app-create-verify.yml
+++ b/.github/workflows/app-create-verify.yml
@@ -9,7 +9,7 @@ on:
     inputs:
       python-version:
         description: "Python version to use; defaults to latest Python release."
-        default: "3.X"
+        default: "3.x"
         type: string
       runner-os:
         description: "The OS to use to build the App; must be a fully qualified GitHub runner OS, e.g. ubuntu-latest."
@@ -72,6 +72,7 @@ jobs:
       with:
         python-version: ${{ inputs.python-version }}
         cache: pip
+        allow-prereleases: true
         cache-dependency-path: |
           **/setup.cfg
           **/pyproject.toml

--- a/.github/workflows/app-create-verify.yml
+++ b/.github/workflows/app-create-verify.yml
@@ -79,7 +79,7 @@ jobs:
       # require the use of sudo, or extra workarounds for user-space packages.
       uses: actions/setup-python@v5.2.0
       with:
-        python-version: ${{ startsWith(inputs.runner-os, 'ubuntu') && inputs.python-version == 'system' && steps.config.outputs.system-python-version || inputs.python-version }}
+        python-version: ${{ startsWith(inputs.runner-os, 'ubuntu') && inputs.python-version == 'system' && steps.config.outputs.system-python-version || inputs.python-version || '3.x' }}
         cache: pip
         allow-prereleases: true
         cache-dependency-path: |

--- a/.github/workflows/app-create-verify.yml
+++ b/.github/workflows/app-create-verify.yml
@@ -47,6 +47,11 @@ jobs:
     runs-on: ${{ inputs.runner-os }}
     timeout-minutes: 30
     steps:
+    - name: Workflow Configuration
+      id: config
+      run: |
+        SYSTEM_PYTHON_VER=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+        echo "system-python-version=${SYSTEM_PYTHON_VER}" | tee -a ${GITHUB_OUTPUT}
 
     - name: Checkout ${{ inputs.repository }}
       uses: actions/checkout@v4.2.0
@@ -68,10 +73,10 @@ jobs:
         path: briefcase-template
 
     - name: Set up Python
-      if: ${{ inputs.python-version != 'system' }}
+      # Always set up a Python, so that dependencies can be installed without sudo access
       uses: actions/setup-python@v5.2.0
       with:
-        python-version: ${{ inputs.python-version }}
+        python-version: ${{ inputs.python-version == 'system' && steps.config.system-python-version || inputs.python-version }}
         cache: pip
         allow-prereleases: true
         cache-dependency-path: |

--- a/.github/workflows/app-create-verify.yml
+++ b/.github/workflows/app-create-verify.yml
@@ -68,8 +68,7 @@ jobs:
         path: briefcase-template
 
     - name: Set up Python
-      # Linux System apps can only use the system Python to run the app
-      if: ${{ !startsWith(inputs.runner-os, 'ubuntu') || inputs.python-version != 'system' }}
+      if: ${{ inputs.python-version != 'system' }}
       uses: actions/setup-python@v5.2.0
       with:
         python-version: ${{ inputs.python-version }}

--- a/.github/workflows/app-create-verify.yml
+++ b/.github/workflows/app-create-verify.yml
@@ -68,6 +68,8 @@ jobs:
         path: briefcase-template
 
     - name: Set up Python
+      # Linux System apps can only use the system Python to run the app
+      if: ${{ !startsWith(inputs.runner-os, 'ubuntu') || inputs.python-version != 'system' }}
       uses: actions/setup-python@v5.2.0
       with:
         python-version: ${{ inputs.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,7 @@ jobs:
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      python-version: "3.11"
+      python-version: "3.11"  # Explicitly test the python-version override
       repository: beeware/briefcase-template
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
@@ -306,7 +306,6 @@ jobs:
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      python-version: "3.11"
       repository: beeware/briefcase-android-gradle-template
       runner-os: ${{ matrix.runner-os }}
       target-platform: android
@@ -323,7 +322,6 @@ jobs:
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      python-version: "3.11"
       repository: beeware/briefcase-iOS-xcode-template
       runner-os: macos-latest
       target-platform: iOS
@@ -355,7 +353,6 @@ jobs:
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      python-version: "3.11"
       repository: beeware/briefcase-linux-appimage-template
       runner-os: ubuntu-latest
       target-platform: linux
@@ -372,7 +369,6 @@ jobs:
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      python-version: "3.11"
       repository: beeware/briefcase-linux-flatpak-template
       runner-os: ubuntu-latest
       target-platform: linux
@@ -388,7 +384,6 @@ jobs:
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      python-version: "3.11"
       repository: beeware/briefcase-macos-${{ matrix.format }}-template
       runner-os: macos-latest
       target-platform: macOS
@@ -405,7 +400,6 @@ jobs:
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      python-version: "3.11"
       repository: beeware/briefcase-web-static-template
       runner-os: ubuntu-latest
       target-platform: web
@@ -421,7 +415,6 @@ jobs:
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      python-version: "3.11"
       repository: beeware/briefcase-windows-${{ matrix.format }}-template
       runner-os: windows-latest
       target-platform: windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,6 @@ jobs:
     needs: [ pre-commit, test-package-python ]
     uses: ./.github/workflows/app-create-verify.yml
     with:
-      python-version: "system"  # must match system python for ubuntu version
       repository: beeware/briefcase
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
@@ -270,13 +269,16 @@ jobs:
       matrix:
         framework: [ toga, pyside6 ]
         runner-os: [ macos-latest, windows-latest, ubuntu-22.04 ]
+        includes:
+          # Ubuntu apps need to run on the system Python
+          - runner-os: ubuntu-22.04
+            python-version: "system"
 
   test-verify-apps-briefcase:
     name: Verify Briefcase
     needs: [ pre-commit, test-package-python ]
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      python-version: "system"  # must match system python for ubuntu version
       repository: beeware/briefcase
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
@@ -285,6 +287,10 @@ jobs:
       matrix:
         framework: [ toga ]
         runner-os: [ macos-latest, windows-latest, ubuntu-22.04 ]
+        includes:
+          # Ubuntu apps need to run on the system Python
+          - runner-os: ubuntu-22.04
+            python-version: "system"
 
   test-verify-apps-briefcase-template:
     name: Verify Briefcase Template
@@ -337,7 +343,8 @@ jobs:
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      python-version: "system"  # must match system python for ubuntu version
+      # Ubuntu apps need to run on the system Python
+      python-version: "system"
       repository: beeware/briefcase-linux-system-template
       runner-os: ubuntu-22.04
       target-platform: linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,7 @@ jobs:
     needs: [ pre-commit, test-package-python ]
     uses: ./.github/workflows/app-create-verify.yml
     with:
-      python-version: "3.10"  # must match system python for ubuntu version
+      python-version: "system"  # must match system python for ubuntu version
       repository: beeware/briefcase
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
@@ -276,7 +276,7 @@ jobs:
     needs: [ pre-commit, test-package-python ]
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      python-version: "3.10"  # must match system python for ubuntu version
+      python-version: "system"  # must match system python for ubuntu version
       repository: beeware/briefcase
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
@@ -337,7 +337,7 @@ jobs:
     needs: pre-commit
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      python-version: "3.10"  # must match system python for ubuntu version
+      python-version: "system"  # must match system python for ubuntu version
       repository: beeware/briefcase-linux-system-template
       runner-os: ubuntu-22.04
       target-platform: linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,7 @@ jobs:
     needs: [ pre-commit, test-package-python ]
     uses: ./.github/workflows/app-create-verify.yml
     with:
+      python-version: ${{ matrix.python-version}} # Falls back to 3.x if undefined
       repository: beeware/briefcase
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
@@ -279,6 +280,7 @@ jobs:
     needs: [ pre-commit, test-package-python ]
     uses: ./.github/workflows/app-build-verify.yml
     with:
+      python-version: ${{ matrix.python-version}} # Falls back to 3.x if undefined
       repository: beeware/briefcase
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,7 @@ jobs:
     needs: [ pre-commit, test-package-python ]
     uses: ./.github/workflows/app-create-verify.yml
     with:
-      python-version: ${{ matrix.python-version}} # Falls back to 3.x if undefined
+      python-version: ${{ matrix.python-version }} # Falls back to 3.x if undefined
       repository: beeware/briefcase
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
@@ -280,7 +280,7 @@ jobs:
     needs: [ pre-commit, test-package-python ]
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      python-version: ${{ matrix.python-version}} # Falls back to 3.x if undefined
+      python-version: ${{ matrix.python-version }} # Falls back to 3.x if undefined
       repository: beeware/briefcase
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5.2.0
       with:
-        python-version: 3.X
+        python-version: "3.x"
         cache: pip
         cache-dependency-path: |
           **/setup.cfg

--- a/.github/workflows/dep-version-bump.yml
+++ b/.github/workflows/dep-version-bump.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5.2.0
         with:
-          python-version: 3.X
+          python-version: "3.x"
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/pre-commit-run.yml
+++ b/.github/workflows/pre-commit-run.yml
@@ -9,7 +9,7 @@ on:
     inputs:
       python-version:
         description: "Python version to use; defaults to latest Python release."
-        default: "3.X"
+        default: "3.x"
         type: string
       repository:
         description: "GitHub repository to checkout; defaults to repo running this workflow."
@@ -44,6 +44,7 @@ jobs:
       uses: actions/setup-python@v5.2.0
       with:
         python-version: ${{ inputs.python-version }}
+        allow-prereleases: true
         cache: pip
         cache-dependency-path: |
           **/setup.cfg

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5.2.0
         with:
-          python-version: 3.X
+          python-version: "3.x"
           cache: pip
           cache-dependency-path: |
             **/setup.cfg

--- a/.github/workflows/towncrier-run.yml
+++ b/.github/workflows/towncrier-run.yml
@@ -9,7 +9,7 @@ on:
     inputs:
       python-version:
         description: "Python version to use; defaults to latest Python release."
-        default: "3.X"
+        default: "3.x"
         type: string
       repository:
         description: "GitHub repository to checkout; defaults to repo running this workflow."
@@ -55,6 +55,7 @@ jobs:
       uses: actions/setup-python@v5.2.0
       with:
         python-version: ${{ inputs.python-version }}
+        allow-prereleases: true
         cache: pip
         cache-dependency-path: |
           **/setup.cfg


### PR DESCRIPTION
Enable the use of [`allow-prereleases`](https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#allow-pre-releases) when setting up Python.

This allows us to use a bare version number for pre-release Python versions, rather than needing to add (and often remove at runtime) the `-dev` suffix. Given we're about to do a big push of adding 3.14, and removing the -dev suffix from  3.13, it seemed opportune to get this in place.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
