### PR TITLE
Exclude pyproject.toml from dependency version bumps

### DIFF
--- a/.github/workflows/dep-version-bump.yml
+++ b/.github/workflows/dep-version-bump.yml
@@ -14,6 +14,10 @@ on:
         description: "Whitespace-delimited list of directories containing pyproject.toml and tox.ini files; defaults to repo's base directory."
         default: ""
         type: string
+      filenames:
+        description: "Whitespace-delimited list of filenames to evaluate for dependency version bumps; defaults to only tox.ini."
+        default: "tox.ini"
+        type: string
       create-changenote:
         description: "Defaults 'true' to create a misc changenote in the './changes' directory."
         default: true
@@ -83,10 +87,10 @@ jobs:
         working-directory: "repo"
         run: |
           if [ "${{ inputs.subdirectory }}" == "" ]; then
-            python ../beeware-.github/scripts/bump_versions.py
+            python ../beeware-.github/scripts/bump_versions.py --filenames ${{ inputs.filenames }}
           else
             for SUBDIR in ${{ inputs.subdirectory }}; do
-              python ../beeware-.github/scripts/bump_versions.py ${SUBDIR}
+              python ../beeware-.github/scripts/bump_versions.py ${SUBDIR} --filenames ${{ inputs.filenames }}
             done
           fi
 

--- a/scripts/bump_versions.py
+++ b/scripts/bump_versions.py
@@ -63,6 +63,16 @@ def parse_args():
             "defaults to current directory"
         ),
     )
+    parser.add_argument(
+        "--filenames",
+        default="",
+        nargs="+",
+        choices=["tox.ini", "pyproject.toml"],
+        help=(
+            "One or more filenames to evaluate. "
+            "All supported files are evaluated if not specified."
+        ),
+    )
 
     args = parser.parse_args()
     print(f"\nEvaluating {args.subdirectory}")
@@ -196,8 +206,10 @@ def main():
     ret_code = 0
     try:
         args = parse_args()
-        update_pyproject_toml(base_dir=args.subdirectory)
-        update_tox_ini(base_dir=args.subdirectory)
+        if not args.filenames or "pyproject.toml" in args.filenames:
+            update_pyproject_toml(base_dir=args.subdirectory)
+        if not args.filenames or "tox.ini" in args.filenames:
+            update_tox_ini(base_dir=args.subdirectory)
     except BumpVersionError as e:
         print(e.msg)
         ret_code = e.error_no


### PR DESCRIPTION
## Changes
- Dependabot now handles pyproject.toml; only bump tox.ini
- Fixes #185

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct