### PR TITLE
Ensure build-essential is installed for local system builds.

### DIFF
--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -227,7 +227,7 @@ jobs:
         && contains(fromJSON('["", "system"]'), inputs.target-format)
       working-directory: ${{ steps.create.outputs.project-path }}
       run: |
-        PACKAGES="python3-dev python3-pip"
+        PACKAGES="python3-dev python3-pip build-essential"
         case "$(tr '[:upper:]' '[:lower:]' <<< '${{ inputs.framework }}')" in
           toga    ) PACKAGES="${PACKAGES} ${{ env.TOGA_SYSTEM_REQUIRES }}" ;;
           pyside6 ) PACKAGES="${PACKAGES} ${{ env.PYSIDE6_SYSTEM_REQUIRES }}" ;;


### PR DESCRIPTION
Github's CI has removed build-essential from their CI setup (but not the underlying tools), causing build failures on Briefcase. (See also beeware/toga#3052).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
