### PR TITLE
Add support for linux arm64 runners

### DIFF
--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -241,7 +241,7 @@ jobs:
         xvfb-run briefcase run linux system
         briefcase package linux system --adhoc-sign
 
-        bash -c "sudo apt -y install --dry-run ./dist/*_0.0.1-1~ubuntu-*_amd64.deb"
+        bash -c "sudo apt -y install --dry-run ./dist/*_0.0.1-1~ubuntu-*_$(dpkg --print-architecture).deb"
 
     - name: Log in to GitHub Container Registry
       if: >
@@ -309,7 +309,9 @@ jobs:
         briefcase package linux system --target debian:bookworm --adhoc-sign
 
         docker run --volume $(pwd)/dist:/dist debian:bookworm \
-          sh -c "apt update && apt -y install --dry-run /dist/*_0.0.1-1~debian-*_amd64.deb"
+          sh -c "\
+            apt update && \
+            apt -y install --dry-run /dist/*_0.0.1-1~debian-*_$(dpkg --print-architecture).deb"
 
     - name: Build Linux System Project (Fedora, Dockerized)
       if: >
@@ -318,21 +320,23 @@ jobs:
         && contains(fromJSON('["", "system"]'), inputs.target-format)
       working-directory: ${{ steps.create.outputs.project-path }}
       env:
-        PKG_TAG: ${{ steps.docker.outputs.tag-base }}-system-fedora-39
+        PKG_TAG: ${{ steps.docker.outputs.tag-base }}-system-fedora-41
       run: |
-        briefcase create linux system --target fedora:39 \
+        briefcase create linux system --target fedora:41 \
           ${{ steps.output-format.outputs.template-override }} \
           ${DOCKER_BUILDX_OPTIONS//__PKG_TAG__/${PKG_TAG}}
-        briefcase build linux system --target fedora:39
-        xvfb-run briefcase run linux system --target fedora:39
-        briefcase package linux system --target fedora:39 --adhoc-sign
+        briefcase build linux system --target fedora:41
+        xvfb-run briefcase run linux system --target fedora:41
+        briefcase package linux system --target fedora:41 --adhoc-sign
 
         docker run --volume $(pwd)/dist:/dist fedora:39 \
-          sh -c "yum -y install --downloadonly /dist/*-0.0.1-1.fc*.x86_64.rpm"
+          sh -c "yum -y install --downloadonly /dist/*-0.0.1-1.fc*.$(rpm --eval '%_arch').rpm"
 
     - name: Build Linux System Project (Arch, Dockerized)
+      # Arch is not officially supported on ARM
       if: >
         startsWith(inputs.runner-os, 'ubuntu')
+        && !endsWith(inputs.runner-os, '-arm')
         && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
         && contains(fromJSON('["", "system"]'), inputs.target-format)
       working-directory: ${{ steps.create.outputs.project-path }}
@@ -347,7 +351,9 @@ jobs:
         briefcase package linux system --target archlinux:latest --adhoc-sign
 
         docker run --volume $(pwd)/dist:/dist archlinux \
-          sh -c "pacman --sync --refresh && pacman --noconfirm --upgrade --print /dist/*-0.0.1-1-x86_64.pkg.tar.zst"
+          sh -c "\
+            pacman --sync --refresh && \
+            pacman --noconfirm --upgrade --print /dist/*-0.0.1-1-x86_64.pkg.tar.zst"
 
     - name: Build Linux System Project (openSUSE, Dockerized)
       if: >
@@ -366,7 +372,9 @@ jobs:
         briefcase package linux system --target opensuse/tumbleweed:latest --adhoc-sign
 
         docker run --volume $(pwd)/dist:/dist opensuse/tumbleweed \
-          sh -c "zypper --non-interactive --no-gpg-checks install --dry-run /dist/*-0.0.1-1.x86_64.rpm"
+          sh -c "\
+            zypper --non-interactive --no-gpg-checks \
+              install --dry-run /dist/*-0.0.1-1.$(rpm --eval '%_arch').rpm"
 
     # 2024-09-02 AppImage testing disabled entirely In Briefcase#1977, the
     # Bootstrap app was updated to use a Toga API introduced in Toga 0.4.6. This
@@ -447,8 +455,10 @@ jobs:
         briefcase package linux flatpak --adhoc-sign
 
     - name: Build Android App
+      # Android SDK is not compatible with ARM
       if: >
         contains(fromJSON('["", "Android"]'), inputs.target-platform)
+        && !endsWith(inputs.runner-os, '-arm')
         && contains(fromJSON('["", "Gradle"]'), inputs.target-format)
         && startsWith(inputs.framework, 'toga')
       working-directory: ${{ steps.create.outputs.project-path }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
   test-install-briefcase:
     name: Install Briefcase
     needs: pre-commit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -191,7 +191,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner-os: [ macos-latest, windows-latest, ubuntu-latest ]
+        runner-os: [ macos-latest, windows-latest, ubuntu-24.04 ]
     steps:
       - name: Checkout beeware/briefcase
         uses: actions/checkout@v4.2.2
@@ -261,7 +261,8 @@ jobs:
     needs: [ pre-commit, test-package-python ]
     uses: ./.github/workflows/app-create-verify.yml
     with:
-      python-version: ${{ matrix.python-version }} # Falls back to 3.x if undefined
+      # Falls back to 3.x in called workflow if undefined
+      python-version: ${{ startsWith(matrix.runner-os, 'ubuntu') && 'system' || '' }}
       repository: beeware/briefcase
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
@@ -269,18 +270,15 @@ jobs:
       fail-fast: false
       matrix:
         framework: [ toga, pyside6 ]
-        runner-os: [ macos-latest, windows-latest, ubuntu-22.04 ]
-        includes:
-          # Ubuntu apps need to run on the system Python
-          - runner-os: ubuntu-22.04
-            python-version: "system"
+        runner-os: [ macos-latest, windows-latest, ubuntu-24.04, ubuntu-24.04-arm ]
 
   test-verify-apps-briefcase:
     name: Verify Briefcase
     needs: [ pre-commit, test-package-python ]
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      python-version: ${{ matrix.python-version }} # Falls back to 3.x if undefined
+      # Falls back to 3.x in called workflow if undefined
+      python-version: ${{ startsWith(matrix.runner-os, 'ubuntu') && 'system' || '' }}
       repository: beeware/briefcase
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
@@ -288,11 +286,7 @@ jobs:
       fail-fast: false
       matrix:
         framework: [ toga ]
-        runner-os: [ macos-latest, windows-latest, ubuntu-22.04 ]
-        includes:
-          # Ubuntu apps need to run on the system Python
-          - runner-os: ubuntu-22.04
-            python-version: "system"
+        runner-os: [ macos-latest, windows-latest, ubuntu-24.04, ubuntu-24.04-arm ]
 
   test-verify-apps-briefcase-template:
     name: Verify Briefcase Template
@@ -307,7 +301,7 @@ jobs:
       fail-fast: false
       matrix:
         framework: [ toga ]
-        runner-os: [ macos-latest, windows-latest, ubuntu-latest ]
+        runner-os: [ macos-latest, windows-latest, ubuntu-24.04, ubuntu-24.04-arm ]
 
   test-verify-apps-android-templates:
     name: Verify Android
@@ -323,7 +317,7 @@ jobs:
       fail-fast: false
       matrix:
         framework: [ toga ]  # toga only
-        runner-os: [ macos-latest, windows-latest, ubuntu-latest ]
+        runner-os: [ macos-latest, windows-latest, ubuntu-24.04 ]
 
   test-verify-apps-iOS-templates:
     name: Verify iOS
@@ -348,7 +342,7 @@ jobs:
       # Ubuntu apps need to run on the system Python
       python-version: "system"
       repository: beeware/briefcase-linux-system-template
-      runner-os: ubuntu-22.04
+      runner-os: ${{ matrix.runner-os }}
       target-platform: linux
       target-format: system
       framework: ${{ matrix.framework }}
@@ -356,22 +350,24 @@ jobs:
       fail-fast: false
       matrix:
         framework: [ toga, pyside6, pygame, console ]
+        runner-os: [ ubuntu-24.04, ubuntu-24.04-arm ]
 
-  test-verify-apps-appimage-templates:
-    name: Verify AppImage
-    needs: pre-commit
-    uses: ./.github/workflows/app-build-verify.yml
-    with:
-      repository: beeware/briefcase-linux-appimage-template
-      runner-os: ubuntu-latest
-      target-platform: linux
-      target-format: appimage
-      framework: ${{ matrix.framework }}
-    strategy:
-      fail-fast: false
-      matrix:
-        # 2024-07-11 (beeware/briefcase#1908): pyside6 segfaults on AppImage start.
-        framework: [ toga, pygame, console ]
+# see app-build-verify.yml; AppImage testing was disabled sept 2024
+#  test-verify-apps-appimage-templates:
+#    name: Verify AppImage
+#    needs: pre-commit
+#    uses: ./.github/workflows/app-build-verify.yml
+#    with:
+#      repository: beeware/briefcase-linux-appimage-template
+#      runner-os: ${{ matrix.runner-os }}
+#      target-platform: linux
+#      target-format: appimage
+#      framework: ${{ matrix.framework }}
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        # 2024-07-11 (beeware/briefcase#1908): pyside6 segfaults on AppImage start.
+#        framework: [ toga, pygame, console ]
 
   test-verify-apps-flatpak-templates:
     name: Verify Flatpak
@@ -379,7 +375,7 @@ jobs:
     uses: ./.github/workflows/app-build-verify.yml
     with:
       repository: beeware/briefcase-linux-flatpak-template
-      runner-os: ubuntu-latest
+      runner-os: ${{ matrix.runner-os }}
       target-platform: linux
       target-format: flatpak
       framework: ${{ matrix.framework }}
@@ -387,6 +383,7 @@ jobs:
       fail-fast: false
       matrix:
         framework: [ toga, pyside6, pygame, console ]
+        runner-os: [ ubuntu-24.04, ubuntu-24.04-arm ]
 
   test-verify-apps-macOS-templates:
     name: Verify macOS
@@ -410,7 +407,7 @@ jobs:
     uses: ./.github/workflows/app-build-verify.yml
     with:
       repository: beeware/briefcase-web-static-template
-      runner-os: ubuntu-latest
+      runner-os: ubuntu-24.04
       target-platform: web
       target-format: static
       framework: ${{ matrix.framework }}


### PR DESCRIPTION
## Changes
- Adds 12 more jobs for testing Linux on ARM
- Bumps fedora from 39 to 41
- Aligns all Linux builds on Ubuntu 24.04

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
