### PR TITLE
Disable weekly cron for in-repo dependency updates

### DIFF
--- a/.github/workflows/dep-version-bump.yml
+++ b/.github/workflows/dep-version-bump.yml
@@ -5,8 +5,6 @@ name: Update Dependency Versions
 #######
 
 on:
-  schedule:
-    - cron: "0 20 * * SUN"  # Sunday @ 2000 UTC
   workflow_dispatch:
   workflow_call:
     inputs:


### PR DESCRIPTION
#186 added a change that parameterized the list of files passed to the dependency update script. This change works fine when the action is executed as a triggered workflow; however, when it runs as a cron (natively in this repo), the inputs are undefined. This was [causing workflow errors](https://github.com/beeware/.github/actions/runs/11999268548)

This pointed out that the action isn't required as a weekly cros - [even when it ran successfully, it was a no-op](https://github.com/beeware/.github/actions/runs/11881910518/job/33106800684), because this repo doesn't have a pyproject.toml or a tox.ini.

This PR removes the cron entry for the workflow. It will still be run weekly on repos that import it as a workflow.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
