### PR TITLE
Bump isort from 5.13.2 to 6.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: pyupgrade
         args: [--py38-plus]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+    rev: 6.0.0
     hooks:
       - id: isort
         args: [--profile=black, --split-on-trailing-comma, --combine-as]


### PR DESCRIPTION
Bumps `pre-commit` hook for `isort` from 5.13.2 to 6.0.0 and ran the update against the repo.