### PR TITLE
Switch to Debian Trixie for testing.

### DIFF
--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -289,7 +289,7 @@ jobs:
         echo "DOCKER_BUILDX_OPTIONS=${BUILDX_OPTIONS[@]}" | tee -a ${GITHUB_ENV}
 
         # Tag format: app-build-<year>-<month>-<framework>-<python-version>-<format>-<format-differentiators>-<branch>
-        # For example: app-build-24-02-toga-3.11-system-debian-bookworm-main
+        # For example: app-build-24-02-toga-3.11-system-debian-trixie-main
         echo "tag-base=app-build-$(date +%Y-%m)-${{ inputs.framework }}-${{ inputs.python-version }}" | tee -a ${GITHUB_OUTPUT}
 
     - name: Build Linux System Project (Debian, Dockerized)
@@ -299,16 +299,16 @@ jobs:
         && contains(fromJSON('["", "system"]'), inputs.target-format)
       working-directory: ${{ steps.create.outputs.project-path }}
       env:
-        PKG_TAG: ${{ steps.docker.outputs.tag-base }}-system-debian-bookworm
+        PKG_TAG: ${{ steps.docker.outputs.tag-base }}-system-debian-trixie
       run: |
-        briefcase create linux system --target debian:bookworm \
+        briefcase create linux system --target debian:trixie \
           ${{ steps.output-format.outputs.template-override }} \
           ${DOCKER_BUILDX_OPTIONS//__PKG_TAG__/${PKG_TAG}}
-        briefcase build linux system --target debian:bookworm
-        xvfb-run briefcase run linux system --target debian:bookworm
-        briefcase package linux system --target debian:bookworm --adhoc-sign
+        briefcase build linux system --target debian:trixie
+        xvfb-run briefcase run linux system --target debian:trixie
+        briefcase package linux system --target debian:trixie --adhoc-sign
 
-        docker run --volume $(pwd)/dist:/dist debian:bookworm \
+        docker run --volume $(pwd)/dist:/dist debian:trixie \
           sh -c "\
             apt update && \
             apt -y install --dry-run /dist/*_0.0.1-1~debian-*_$(dpkg --print-architecture).deb"


### PR DESCRIPTION
Part of the beeware/toga#3143 response.

Debian Bookworm doesn't provide libgirepository-2.0, so it can't use a recent PyGObject release. Switch to Trixie (not yet formally released, but pre-release Debian images are available) so that we can continue to test Debian without needing all sorts of config overrides.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
