### PR TITLE
Make the Xcode and simulator version configurable.

### DIFF
--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -16,6 +16,14 @@ on:
         description: "The OS to use to build the App; must be a fully qualified GitHub runner OS, e.g. ubuntu-latest."
         required: true
         type: string
+      xcode-version:
+        description: "The XCode version to use"
+        default: "16.4"
+        type: string
+      ios-simulator:
+        description: "The iOS simulator image to use"
+        default: "iPhone SE (3rd generation)::16.5"
+        type: string
       framework:
         description: "Framework to use to build the App, e.g. toga."
         required: true
@@ -100,6 +108,16 @@ jobs:
       run: |
         sudo apt -y update
         sudo apt -y install --no-install-recommends socat xauth
+
+    - name: Prepare macOS
+      # GitHub recommends explicitly selecting the desired Xcode version:
+      # https://github.com/actions/runner-images/issues/12541#issuecomment-3083850140
+      # This became a necessity as a result of
+      # https://github.com/actions/runner-images/issues/12541 and
+      # https://github.com/actions/runner-images/issues/12751.
+      if: startsWith(inputs.runner-os, 'macOS')
+      run: |
+        sudo xcode-select --switch /Applications/Xcode_${{ inputs.xcode-version }}.app
 
     - name: Cache Briefcase Tools
       uses: actions/cache@v4.2.4
@@ -499,7 +517,7 @@ jobs:
         briefcase create iOS xcode \
           ${{ steps.output-format.outputs.template-override }}
         briefcase build iOS xcode
-        briefcase run iOS xcode -d "iPhone SE (3rd generation)"
+        briefcase run iOS xcode -d "${{ inputs.ios-simulator }}"
         briefcase package iOS xcode --adhoc-sign
 
     - name: Build Web App


### PR DESCRIPTION
In an attempt to conserve disk space, GitHub Actions has stopped consistently providing iOS simulator images. See 
https://github.com/actions/runner-images/issues/12541 and https://github.com/actions/runner-images/issues/12751 for discussion of this transition.

This means the "default" configuration no longer works for iOS simulation; we need to pick an explicit Xcode version that provides the simulator images we need. We are also in a transition period where the default iOS simulator image is switching from iPhone SE to iPhone 16e; and the iOS version used can radically impact the boot up time of the simulator.

GitHub [recommends explicitly selecting the desired Xcode version](https://github.com/actions/runner-images/issues/12541#issuecomment-3083850140) on every workflow, so we might as well make this configurable; and the iOS simulator is already a configurable item, so we might as well expose it as such.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
