### PR TITLE
Re-enable OpenSUSE testing.

### DIFF
--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -373,29 +373,26 @@ jobs:
             pacman --sync --refresh && \
             pacman --noconfirm --upgrade --print /dist/*-0.0.1-1-x86_64.pkg.tar.zst"
 
-    # 2025-09-29 - OpenSUSE rolled out a change to GDK to use a new image loader
-    # (glycin) that is unable to load PNGs when used inside a Docker container.
-    # Disabling OpenSUSE testing until a fix can be found.
-    # - name: Build Linux System Project (openSUSE, Dockerized)
-    #   if: >
-    #     startsWith(inputs.runner-os, 'ubuntu')
-    #     && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
-    #     && contains(fromJSON('["", "system"]'), inputs.target-format)
-    #   working-directory: ${{ steps.create.outputs.project-path }}
-    #   env:
-    #     PKG_TAG: ${{ steps.docker.outputs.tag-base }}-system-opensuse
-    #   run: |
-    #     briefcase create linux system --target opensuse/tumbleweed:latest \
-    #       ${{ steps.output-format.outputs.template-override }} \
-    #       ${DOCKER_BUILDX_OPTIONS//__PKG_TAG__/${PKG_TAG}}
-    #     briefcase build linux system --target opensuse/tumbleweed:latest
-    #     xvfb-run briefcase run linux system --target opensuse/tumbleweed:latest
-    #     briefcase package linux system --target opensuse/tumbleweed:latest --adhoc-sign
+    - name: Build Linux System Project (openSUSE, Dockerized)
+      if: >
+        startsWith(inputs.runner-os, 'ubuntu')
+        && contains(fromJSON('["", "Linux"]'), inputs.target-platform)
+        && contains(fromJSON('["", "system"]'), inputs.target-format)
+      working-directory: ${{ steps.create.outputs.project-path }}
+      env:
+        PKG_TAG: ${{ steps.docker.outputs.tag-base }}-system-opensuse
+      run: |
+        briefcase create linux system --target opensuse/tumbleweed:latest \
+          ${{ steps.output-format.outputs.template-override }} \
+          ${DOCKER_BUILDX_OPTIONS//__PKG_TAG__/${PKG_TAG}}
+        briefcase build linux system --target opensuse/tumbleweed:latest
+        xvfb-run briefcase run linux system --target opensuse/tumbleweed:latest
+        briefcase package linux system --target opensuse/tumbleweed:latest --adhoc-sign
 
-    #     docker run --volume $(pwd)/dist:/dist opensuse/tumbleweed \
-    #       sh -c "\
-    #         zypper --non-interactive --no-gpg-checks \
-    #           install --dry-run /dist/*-0.0.1-1.$(rpm --eval '%_arch').rpm"
+        docker run --volume $(pwd)/dist:/dist opensuse/tumbleweed \
+          sh -c "\
+            zypper --non-interactive --no-gpg-checks \
+              install --dry-run /dist/*-0.0.1-1.$(rpm --eval '%_arch').rpm"
 
     # 2024-09-02 AppImage testing disabled entirely In Briefcase#1977, the
     # Bootstrap app was updated to use a Toga API introduced in Toga 0.4.6. This


### PR DESCRIPTION
In #239, OpenSUSE testing was temporarily disabled because of issues with GDK handling of PNG loading inside Docker containers. 

The problem is caused by GNOME moving to the use of `glycin` as an image loader; `glycin` uses `bwrap` as a sandbox, but that sandbox doesn't work when used inside a Docker container. `glycin` 2.0.1 has a fix that disables the sandboxing when in a Docker environment; once that fix has been deployed into OpenSUSE base images, it should be possible to re-enable OpenSUSE testing.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
