### PR TITLE
Make changenote file format configurable.

### DIFF
--- a/.github/workflows/dependabot-changenote.yml
+++ b/.github/workflows/dependabot-changenote.yml
@@ -2,6 +2,11 @@ name: Dependabot Change Note
 
 on:
   workflow_call:
+    inputs:
+      changenote-format:
+        description: "Markup format for the changenote."
+        default: "rst"
+        type: string
     secrets:
       BRUTUS_PAT_TOKEN:
         required: true
@@ -34,7 +39,7 @@ jobs:
         run: |
           # Retrieve PR number from GitHub API
           PR_NUM=$(gh api repos/{owner}/{repo}/commits/${{ github.event.head_commit.id }}/pulls --jq '.[].number')
-          CHANGENOTE_FILEPATH="./changes/${PR_NUM}.misc.rst"
+          CHANGENOTE_FILEPATH="./changes/${PR_NUM}.misc.${{ inputs.changenote-format }}"
 
           # Create change note from first line of dependabot commit
           NEWS=$(printf "%s" "${{ github.event.head_commit.message }}" | head -n1 | sed -e 's/Bump/Updated/')

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -18,6 +18,10 @@ on:
         description: "Defaults 'true' to create a misc changenote in the './changes' directory."
         default: true
         type: boolean
+      changenote-format:
+        description: "Markup format for the changenote."
+        default: "rst"
+        type: string
     secrets:
       BRUTUS_PAT_TOKEN:
         required: true
@@ -131,7 +135,7 @@ jobs:
           git fetch origin
           git checkout "${BRANCH_NAME}"
 
-          FILENAME="${{ env.CHANGENOTE_DIR }}/${{ steps.created-pr.outputs.pull-request-number }}.misc.rst"
+          FILENAME="${{ env.CHANGENOTE_DIR }}/${{ steps.created-pr.outputs.pull-request-number }}.misc.${{ inputs.changenote-format }}"
           printf 'The ``pre-commit`` hook for ``${{ steps.pr.outputs.hook-name }}`` was updated to its latest version.\n' > "${FILENAME}"
 
           git add "${FILENAME}"


### PR DESCRIPTION
With the migration of Toga's docs to Markdown, dependabot and pre-commit updates are generating RST change notes.

This makes the output format configurable. This only means the extension, as there's no markup differences in the actual content of the files (and they're all `.misc` change notes anyway).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
