### PR TITLE
Adapt to the addition of dependency groups in Briefcase.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Test one repository for each way of installing pre-commit.
         repo: [ Python-support-testbed, rubicon-objc, toga ]
         include:
         - repo: rubicon-objc


### PR DESCRIPTION
beeware/briefcase#2502 removed the use of the `dev` extra, and switched to the use of optional dependency groups. This broke some CI workflows (see initial builds of #249). There is also a problem because Briefcase now supports Python 3.14 on Windows, but Python.net doesn't, so Toga verifications can't run on 3.14.

This makes three changes:
* Removes the testing of Briefcase from the pre-commit-run test.
* Switches the `install-requirement` test to use rubicon, rather than Briefcase as a source of dependencies. This also required testing some different dependencies.
* Forces the use of Python 3.13 for the Windows verification tests.

Refs #250.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
