### PR TITLE
Force test-verify-apps-briefcase to use Python 3.13 on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,8 +276,14 @@ jobs:
     needs: [ pre-commit, test-package-python ]
     uses: ./.github/workflows/app-build-verify.yml
     with:
-      # Falls back to 3.x in called workflow if undefined
-      python-version: ${{ startsWith(matrix.runner-os, 'ubuntu') && 'system' || '' }}
+      # Python.net doesn't support 3.14, so we need to force a less recent version on
+      # Windows (see also test-verify-apps-windows-templates).
+      python-version: >-
+        ${{
+          startsWith(matrix.runner-os, 'ubuntu') && 'system'
+          || startsWith(matrix.runner-os, 'windows') && '3.13'
+          || '3.x'
+        }}
       repository: beeware/briefcase
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
@@ -432,7 +438,8 @@ jobs:
       runner-os: windows-latest
       target-platform: windows
       target-format: ${{ matrix.format }}
-      # Python.net doesn't support 3.14, so we need to force a less recent version.
+      # Python.net doesn't support 3.14, so we need to force a less recent version
+      # (see also test-verify-apps-briefcase).
       python-version: "3.13"
       framework: ${{ matrix.framework }}
     strategy:


### PR DESCRIPTION
This wasn't caught in the recent PRs because some runner instances are apparently still resolving `3.x` to Python 3.13, but [this run](https://github.com/beeware/.github/actions/runs/18780049126) used 3.14 and failed.