### PR TITLE
Add workflow for updating Code of Conducts on change to this repository

### DIFF
--- a/.github/workflows/coc-update.yml
+++ b/.github/workflows/coc-update.yml
@@ -14,9 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       repo_list: ${{ steps.repo_list.outputs.repo_list }}
+      commit_hash: ${{ steps.commit_hash.outputs.commit_hash }}
     steps:
     - name: Checkout this repository
       uses: actions/checkout@v4
+    - name: Get latest commit hash
+      id: commit_hash
+      run: |
+        commit_hash=$(git rev-parse --short=16 HEAD)
+        echo "commit_hash=$commit_hash" >> $GITHUB_OUTPUT
     - name: Get list of repositories
       id: repo_list
       run: |
@@ -59,9 +65,12 @@ jobs:
         # Commit and push the update
         echo "Syncing updates to remote..."
         git add CODE_OF_CONDUCT.md
-        git commit -m "Updated code of conduct"
+        git commit -m "Updated Code of Conduct ($GITHUB_REPOSITORY, ${{ needs.plan-coc-update.outputs.commit_hash }})"
         git push --set-upstream origin "$branch_name"
 
         # Create the pull request
-        echo "Creating pull request to upstream..."
-        gh pr create --repo ${{ matrix.full_repo }} --title "Update Code of Conduct" --body "Updated using $GITHUB_REPOSITORY"
+        echo "Creating pull request..."
+        gh pr create \
+              --repo ${{ matrix.full_repo }} \
+              --title "Update Code of Conduct" \
+              --body "Updated via $GITHUB_REPOSITORY (${{ needs.plan-coc-update.outputs.commit_hash }})"


### PR DESCRIPTION
<!--- Describe your changes in detail -->
This allows the Code of Conduct to be updated in this repository, and for that change to be propagated to other public Beeware repositories.  The strategy is a two step process: plan the repositories to update, then attempt to update them in parallel using a matrix.  Changes result in a PR to relevant repositories by Brutus in a new git branch that is timestamped both for uniqueness and record-keeping.
<!--- What problem does this change solve? -->
Maintaining a CoC is good!  Doing it multiple times is painful!  This allows maintainers to standardize a Code of Conduct and simply propagate the change.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ X ] All new features have been tested
_NOTE: To the honest best of my ability without going overboard at this stage.  It is not impossible that I forgot some weird quirk of the way GitHub Actions handles permissions or something.  I tested the premise of actually using the GitHub CLI.  I can create test infrastructure to test if more confidence is desired and no additional changes are requested.  I will say that nothing in this PR is destructive, so the worst case is a dud not a meltdown._
- [ X ] All new features have been documented
- [ X ] I have read the **CONTRIBUTING.md** file
- [ X ] I will abide by the code of conduct
