### PR TITLE
Run pre-commit with Python 3.13 by default

### DIFF
--- a/.github/workflows/pre-commit-run.yml
+++ b/.github/workflows/pre-commit-run.yml
@@ -9,7 +9,7 @@ on:
     inputs:
       python-version:
         description: "Python version to use; defaults to latest Python release."
-        default: "3.x"
+        default: "3.13"  # TODO: restore to 3.x once docformatter is compatible with 3.14
         type: string
       repository:
         description: "GitHub repository to checkout; defaults to repo running this workflow."


### PR DESCRIPTION
## Changes
- GitHub runners are turning over to Python 3.14 as default but docformatter cannot run on 3.14
- This will default pre-commit to run on 3.13 until resolved

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
