### PR TITLE
Drop the default version for pre-commit updates to 3.13

### DIFF
--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -10,6 +10,10 @@ on:
   workflow_dispatch:
   workflow_call:
     inputs:
+      python-version:
+        description: "Python version to use; defaults to latest Python release."
+        default: "3.13"  # TODO: restore to 3.x once docformatter is compatible with 3.14
+        type: string
       pre-commit-source:
         description: "The arguments for `pip install` to install pre-commit; use ./path/to/package[dev] for the repo's pinned version."
         default: ".[dev]"
@@ -79,7 +83,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6.0.0
         with:
-          python-version: "3.x"
+          python-version: ${{ inputs.python-version }}
+          allow-prereleases: true
           cache: pip
           cache-dependency-path: |
             **/setup.cfg


### PR DESCRIPTION
A follow up to #260 - ensure that pre-commit updates also run on Python 3.13 by default.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
