### PR TITLE
Free up disk space on Linux runner

### DIFF
--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -114,7 +114,7 @@ jobs:
 
         # Free up disk space
         docker system prune -a -f
-        sudo rm -rf $ANDROID_HOME/ndk/{26,28}.* /opt/hostedtoolcache/CodeQL \
+        sudo rm -rf $ANDROID_HOME/ndk /opt/hostedtoolcache/CodeQL \
           /usr/local/lib/node_modules /usr/local/share/chromium \
           /usr/local/share/powershell
         df -h


### PR DESCRIPTION
Should fix this failure: https://github.com/beeware/briefcase/actions/runs/19875943952/job/56963552104

Android emulator failures started happening around the same time in the CPython repository, e.g. [this run](https://github.com/python/cpython/actions/runs/19897211275/job/57030696234). The error message is completely different, but emulator error reporting has always been poor, so it's possible it has the same cause.

Toga appears unaffected so far.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
