### PR TITLE
Add some missing runtime dependencies.

### DIFF
--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -71,8 +71,8 @@ jobs:
       packages: write
     env:
       SDL_AUDIODRIVER: dummy  # disable audio for SDL
-      TOGA_SYSTEM_REQUIRES: libthai-dev libegl1 libcairo2-dev libgirepository1.0-dev libgirepository-2.0-dev gir1.2-gtk-3.0
-      PYSIDE6_SYSTEM_REQUIRES: libx11-xcb1 libxkbcommon-x11-0 libxcb-image0 libxcb-cursor0 libxcb-shape0 libxcb-icccm4 libxcb-keysyms1 libgl1 libegl1
+      TOGA_SYSTEM_REQUIRES: libthai-dev libegl1 libcairo2-dev libgirepository1.0-dev libgirepository-2.0-dev gir1.2-gtk-3.0 libcanberra-gtk3-module
+      PYSIDE6_SYSTEM_REQUIRES: libx11-xcb1 libxkbcommon-x11-0 libxcb-image0 libxcb-cursor0 libxcb-shape0 libxcb-icccm4 libxcb-keysyms1 libgl1 libegl1 libglib2.0-0
     steps:
 
     - name: Workflow Configuration


### PR DESCRIPTION
Discovered in the process of developing beeware/briefcase#2592 - there are some packages that are listed as runtime requirements, but aren't installed as part of our test environment. 

These packages are strictly optional, as the tests pass without them being present, but (1) it doesn't hurt to be consistent with the packages that are installed in a Docker environment, and (2) the improved check in #2593 breaks when these packages aren't present.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
