### PR TITLE
Tweak requirements for PySide6

### DIFF
--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -72,7 +72,7 @@ jobs:
     env:
       SDL_AUDIODRIVER: dummy  # disable audio for SDL
       TOGA_SYSTEM_REQUIRES: libcairo2-dev libcanberra-gtk3-module libegl1 libgirepository1.0-dev libgirepository-2.0-dev libthai-dev gir1.2-gtk-3.0
-      PYSIDE6_SYSTEM_REQUIRES: libgl1 libqt6dbus6 libqt6gui6 libxcb-cursor0
+      PYSIDE6_SYSTEM_REQUIRES: libgl1 libqt6dbus6 libqt6gui6t64 libxcb-cursor0
     steps:
 
     - name: Workflow Configuration


### PR DESCRIPTION
Modify the requirements for PySide6 app testing.

While the libglib2.0-0 requirement added in #273 can be installed on Ubuntu using libglib2.0-0, it is actually installed as libglib2.0-0t64. On Debian Bookworm, it's installed as libglib2.0-0 and reports as the same.

This is a common pattern for libraries on Trixie+ (which is what Ubuntu 24.04 is based on). It is related to the 64-bit time_t transition, required to avoid the Y2k38 bug.

Rather than try to enumerate the minimal set of individual packages that are binary requirements for PySide6, this uses the higher level native qt6 packages. This is strictly overkill, as the binary libraries won't be used at runtime, because pyside6 ships its own copies. However, it's a much more convenient way to specify the full set, and it's less error prone over time and  it matches the behaviour of the other Linux platforms. It also explicitly names the t64 variant for the package that will be installed on Ubuntu, so that the package name will roundtrip using the check proposed by beeware/briefcase#2592.

The state of this PR has been validated by beeware/briefcase#2594. For review purposes, [this CI pass of the Briefcase PR](https://github.com/beeware/briefcase/actions/runs/19984719000) was run using this branch of the .github configuration; the Briefcase PR has been reverted to the "main" branch (where it still passes, because the current .github main installs enough system dependencies to start the app natively, and doesn't do requirements validation)

This PR also sorts the dependencies.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
