### PR TITLE
Fix CoC updating workflow

### DIFF
--- a/.github/workflows/coc-update.yml
+++ b/.github/workflows/coc-update.yml
@@ -42,8 +42,16 @@ jobs:
       matrix:
         full_repo: ${{ fromJson(needs.plan-coc-update.outputs.repo_list) }}
     steps:
+    - name: Checkout this repo
+      uses: actions/checkout@v6
+      with:
+        path: sourcerepo
     - name: Checkout repo to be updated
       uses: actions/checkout@v6
+      with:
+        repository: ${{ matrix.full_repo }}
+        path: targetrepo
+        token: ${{ secrets.BRUTUS_PAT_TOKEN }}
     - name: Update Code of Conduct
       env:
         GH_TOKEN: ${{ secrets.BRUTUS_PAT_TOKEN }}
@@ -53,6 +61,9 @@ jobs:
             echo "Skipping source repository ($GITHUB_REPOSITORY)..."
             exit 0
         fi
+
+        # Work within target repo
+        cd targetrepo
 
         # Set the author information to Brutus
         git config --local user.email "brutus@beeware.org"
@@ -66,7 +77,7 @@ jobs:
 
         # Add the new code of conduct
         echo "Replacing Code of Conduct..."
-        cp ../CODE_OF_CONDUCT.md .
+        cp ../sourcerepo/CODE_OF_CONDUCT.md .
 
         # Commit and push the update
         echo "Syncing updates to remote..."


### PR DESCRIPTION
Fixes #281

1. Uses `jq` to correctly turn the list of repositories into JSON for parsing in the child workflow.
2. Corrects the workflow to use `exit` to end the workflow early when skipping the source repository.
3. Performs checkouts for both the source and target repositories, using the Brutus token twice - once in the checkout so `git` operations use its permission, and as `GH_TOKEN` so the `gh` CLI creates the PR with its permissions.

Proof of Concept:
- [Test repository w/ successful workflow run](https://github.com/tekktrik/beeware-coc-fix-poc/actions/runs/20236282554)
- [Target repository where PR was created](https://github.com/tekktrik/test-target-repo/pull/1) (Workflow was slightly modified to only PR this specific repo)

Happy to add the same trick as in the Proof of Concept if we want to be extra safe.