### PR TITLE
Inject CoC edit warning before submitting PRs

### DIFF
--- a/.github/workflows/coc-edit-warning.txt
+++ b/.github/workflows/coc-edit-warning.txt
@@ -1,0 +1,9 @@
+<!--
+  **********************************************************************
+  ***                DO NOT MODIFY THIS FILE DIRECTLY                ***
+  **********************************************************************
+   The original copy of this file is in the beeware/.github repository.
+   It will be automatically copied into other BeeWare repositories when
+   the original is altered. Any changes should be made to the original.
+  **********************************************************************
+-->

--- a/.github/workflows/coc-update.yml
+++ b/.github/workflows/coc-update.yml
@@ -79,6 +79,10 @@ jobs:
         echo "Replacing Code of Conduct..."
         cp ../sourcerepo/CODE_OF_CONDUCT.md .
 
+        # Prepend the edit warning to the file
+        WARNING_TEXT=$(< ../sourcerepo/.github/workflows/coc-edit-warning.txt)
+        printf '%s\n\n' "$WARNING_TEXT" | sed -i '0r /dev/stdin' CODE_OF_CONDUCT.md
+
         # Commit and push the update
         echo "Syncing updates to remote..."
         git add CODE_OF_CONDUCT.md


### PR DESCRIPTION
Prepends a new Code of Conduct file editing warning before submitting PRs to target repos.

See testing here:

Source repo:  https://github.com/tekktrik/beeware-coc-fix-poc
Target repo/PR:  https://github.com/tekktrik/test-target-repo/pull/2

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ X ] All new features have been tested
- [ X ] All new features have been documented
- [ X ] I have read the **CONTRIBUTING.md** file
- [ X ] I will abide by the code of conduct
