### PR TITLE
Remove edit warning from local CoC copy.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,12 +1,3 @@
-<!--
-  **********************************************************************
-  ***                DO NOT MODIFY THIS FILE DIRECTLY                ***
-  **********************************************************************
-   The original copy of this file is in the beeware/.github repository.
-   It will be automatically copied into other BeeWare repositories when
-   the original is altered. Any changes should be made to the original.
-  **********************************************************************
--->
 # BeeWare Community Code of Conduct
 
 ## Our pledge <a name="our-pledge"></a>


### PR DESCRIPTION
CI will now inject the warning at the top of all the files distributed to other repositories. This will alleviate any potential confusion about which version should be edited. 

## PR Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 - [x] All new features have been tested
 - [x] All new features have been documented
 - [x] I have read the **CONTRIBUTING.md** file
 - [x] I will abide by the code of conduct