### PR TITLE
Bump black-pre-commit-mirror from 25.12.0 to 26.1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
   #     - id: docformatter
   #       args: [--in-place, --black]
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.12.0
+    rev: 26.1.0
     hooks:
       - id: black
         language_version: python3


### PR DESCRIPTION
Bumps `pre-commit` hook for `black-pre-commit-mirror` from 25.12.0 to 26.1.0 and ran the update against the repo.