### PR TITLE
Allow for up to 500 repositories to return

### DIFF
--- a/.github/workflows/coc-update.yml
+++ b/.github/workflows/coc-update.yml
@@ -31,7 +31,7 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        repo_list=$(gh repo list $GITHUB_REPOSITORY_OWNER --no-archived --json nameWithOwner --jq ".[].nameWithOwner")
+        repo_list=$(gh repo list $GITHUB_REPOSITORY_OWNER --no-archived --json nameWithOwner --jq ".[].nameWithOwner" -L 500)
         jq_repo_list=$(jq -c -n '$ARGS.positional' --args ${repo_list[@]})
         echo repo_list="$jq_repo_list" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
@kattni had mentioned that this workflow was limited to 30 matches - whoops, turns out the default is 30!

This bumps up the number of returned repositories to 500 - plenty of room to grow.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
