### PR TITLE
Bump rumdl-pre-commit from v0.1.9 to v0.1.15

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,6 @@ repos:
       - id: flake8
         args: [--max-line-length=119]
   - repo: https://github.com/rvben/rumdl-pre-commit
-    rev: v0.1.9
+    rev: v0.1.15
     hooks:
       - id: rumdl


### PR DESCRIPTION
Bumps `pre-commit` hook for `rumdl-pre-commit` from v0.1.9 to v0.1.15 and ran the update against the repo.