### PR TITLE
Bump isort from 8.0.0 to 8.0.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,32 +8,12 @@ repos:
       - id: trailing-whitespace
       - id: check-json
       - id: check-xml
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.2
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.4
     hooks:
-      - id: pyupgrade
-        args: [--py38-plus]
-  - repo: https://github.com/PyCQA/isort
-    rev: 8.0.1
-    hooks:
-      - id: isort
-        args: [--profile=black, --split-on-trailing-comma, --combine-as]
-  # Docformatter 1.7.5 isn't compatible with Pre-commit 4.0
-  # - repo: https://github.com/PyCQA/docformatter
-  #   rev: v1.7.5
-  #   hooks:
-  #     - id: docformatter
-  #       args: [--in-place, --black]
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.1.0
-    hooks:
-      - id: black
-        language_version: python3
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.3.0
-    hooks:
-      - id: flake8
-        args: [--max-line-length=119]
+      - id: ruff-check
+        args: [ --fix ]
+      - id: ruff-format
   - repo: https://github.com/rvben/rumdl-pre-commit
     rev: v0.1.25
     hooks:


### PR DESCRIPTION
Bumps `pre-commit` hook for `isort` from 8.0.0 to 8.0.1 and ran the update against the repo.