### PR TITLE
Bump ruff-pre-commit from v0.15.5 to v0.15.6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: check-json
       - id: check-xml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.5
+    rev: v0.15.6
     hooks:
       - id: ruff-check
         args: [ --fix ]


### PR DESCRIPTION
Bumps `pre-commit` hook for `ruff-pre-commit` from v0.15.5 to v0.15.6 and ran the update against the repo.