### PR TITLE
Create a skinless android emulator.

### DIFF
--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -521,7 +521,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
           briefcase run android gradle \
-            --device '{"avd":"beePhone"}' \
+            --device '{"avd":"beePhone","device_type":"pixel"}' \
             --shutdown-on-exit \
             --Xemulator=-no-window \
             --Xemulator=-no-audio \


### PR DESCRIPTION
We've recently seen a lot of rate limiting (HTTP 429) when downloading a skin for [Android CI builds](https://github.com/beeware/toga/actions/runs/24030637432/job/70078652391). Since a skin is purely cosmetic, it makes sense to provide an option to build a "skinless" build option.

This change modifies the app-build-verify workflow to use the "skinless" option introduced by beeware/briefcase#2788. It will also work before that PR lands, but won't result in a "skinless" behaviour.

UPDATE: The PR has now landed, and CI status reflects usage of the "skinless" behaviour.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
