### PR TITLE
Run pre-commit with latest Python

### DIFF
--- a/.github/workflows/pre-commit-run.yml
+++ b/.github/workflows/pre-commit-run.yml
@@ -9,7 +9,7 @@ on:
     inputs:
       python-version:
         description: "Python version to use; defaults to latest Python release."
-        default: "3.13"  # TODO: restore to 3.x once docformatter is compatible with 3.14
+        default: "3.x"
         type: string
       repository:
         description: "GitHub repository to checkout; defaults to repo running this workflow."


### PR DESCRIPTION
This PR reverts https://github.com/beeware/.github/pull/260, which pinned the pre-commit Python version to 3.13 until docformatter supports 3.14.

97ac9c52f160ca0d5eede41fade0fa7079de7610 removed docformatter from the pre-commit config, so that bandaid is not necessary anymore.
Also, [docformatter v1.7.8](https://github.com/PyCQA/docformatter/releases/tag/v1.7.8) was just released, now supporting Python 3.14: https://github.com/PyCQA/docformatter/pull/342.

## PR Checklist:
Sorry, I don't know how to test or document this.

- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
