### PR TITLE
Bump rumdl-pre-commit from v0.1.83 to v0.1.87

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,6 @@ repos:
         args: [ --fix ]
       - id: ruff-format
   - repo: https://github.com/rvben/rumdl-pre-commit
-    rev: v0.1.83
+    rev: v0.1.87
     hooks:
       - id: rumdl


### PR DESCRIPTION
Bumps `pre-commit` hook for `rumdl-pre-commit` from v0.1.83 to v0.1.87 and ran the update against the repo.