### PR TITLE
Install workflow deps from pyproject.toml dependency groups

### DIFF
--- a/.github/workflows/app-create-verify.yml
+++ b/.github/workflows/app-create-verify.yml
@@ -91,7 +91,7 @@ jobs:
       run: python -m pip install -U pip
 
     - name: Install Dependencies
-      run: python -m pip install --group test --group dev ./briefcase-template
+      run: python -m pip install --group ./briefcase-template:test --group ./briefcase-template:dev
 
     - name: Get Briefcase Package
       # Briefcase will build and package itself in a previous step in its CI

--- a/.github/workflows/app-create-verify.yml
+++ b/.github/workflows/app-create-verify.yml
@@ -87,9 +87,11 @@ jobs:
           **/pyproject.toml
           .pre-commit-config.yaml
 
+    - name: Update pip
+      run: python -m pip install -U pip
+
     - name: Install Dependencies
-      # must install before Briefcase below since requirements.txt contains an entry for Briefcase
-      run: python -m pip install -Ur ./briefcase-template/requirements.txt
+      run: python -m pip install --group test --group dev ./briefcase-template
 
     - name: Get Briefcase Package
       # Briefcase will build and package itself in a previous step in its CI

--- a/.github/workflows/app-create-verify.yml
+++ b/.github/workflows/app-create-verify.yml
@@ -91,7 +91,7 @@ jobs:
       run: python -m pip install -U pip
 
     - name: Install Dependencies
-      run: python -m pip install --group ./briefcase-template:test --group ./briefcase-template:dev
+      run: python -m pip install --group './briefcase-template/pyproject.toml:test' --group './briefcase-template/pyproject.toml:dev'
 
     - name: Get Briefcase Package
       # Briefcase will build and package itself in a previous step in its CI


### PR DESCRIPTION
Replace the hardcoded requirements.txt install with --group reads from briefcase-template's pyproject.toml, unblocking the migration in beeware/briefcase-template#236.

<!--- Describe your changes in detail -->
Update `app-create-verify.yml` to install briefcase-template's workflow dependencies via PEP 735 dependency groups (`--group`) instead of `requirements.txt`. Adds a pip upgrade step since `--group` requires pip ≥ 25.1.

<!--- What problem does this change solve? -->
Unblocks beeware/briefcase-template#236, which migrates that repo to `pyproject.toml`. The workflow currently hardcodes `pip install -Ur ./briefcase-template/requirements.txt`, so deleting the file in the consumer repo would break this workflow for all consumers. Once this lands, the temporary `requirements.txt` stub in briefcase-template can be removed.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #355
Refs beeware/briefcase-template#236

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: Claude Opus 4.7