### PR TITLE
Migrate app-create-verify to pyproject.toml

### DIFF
--- a/.github/workflows/app-create-verify.yml
+++ b/.github/workflows/app-create-verify.yml
@@ -87,9 +87,11 @@ jobs:
           **/pyproject.toml
           .pre-commit-config.yaml
 
+    - name: Update pip
+      run: python -m pip install -U pip
+
     - name: Install Dependencies
-      # must install before Briefcase below since requirements.txt contains an entry for Briefcase
-      run: python -m pip install -Ur ./briefcase-template/requirements.txt
+      run: python -m pip install --group './briefcase-template/pyproject.toml:create-verify'
 
     - name: Get Briefcase Package
       # Briefcase will build and package itself in a previous step in its CI


### PR DESCRIPTION
<!--- Describe your changes in detail -->
  - Replaces `python -m pip install -Ur ./briefcase-template/requirements.txt` with `python -m pip install --group ./briefcase-template/pyproject.toml:create-verify`
  - Updates pip to ensure support of the `--group` feature
  - The new create-verify dependency group in briefcase-template contains exactly `black`, `flake8`, and `toml` — the only packages this workflow directly invokes
  - Drops the extraneous briefcase, pre-commit, pytest, and tox that were previously installed but unused by this workflow


<!--- What problem does this change solve? -->
Requirements.txt in briefcase-template is to be deprecated. This is the only location that uses it.
Group in pyproject.toml pins exactly the surface this workflow needs.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #355 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: Claude Opus 4.7, Claude Sonnet 4.6
