### PR TITLE
Updated code style link for pre-commit-run.yaml

### DIFF
--- a/.github/workflows/pre-commit-run.yml
+++ b/.github/workflows/pre-commit-run.yml
@@ -79,7 +79,7 @@ jobs:
         echo '::error:: '
         echo '::error::Visit the docs below to configure pre-commit in your dev environment:'
         echo '::error:: '
-        echo '::error::    https://beeware.org/contributing/how/process#code-style'
+        echo '::error::    https://beeware.org/contributing/guide/style/code-style-guide/'
         echo '::error:: '
         echo '::error::*************************************************************************'
         exit 1


### PR DESCRIPTION
Pre-commit-run.yaml link was deprecated. Previously (https://beeware.org/contributing/how/process#code-style) Changed to the updated link: https://beeware.org/contributing/guide/style/code-style-guide/


## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file