### PR TITLE
Add feature for towncrier-run.yml to comment on PR when it fails.

### DIFF
--- a/.github/workflows/towncrier-run.yml
+++ b/.github/workflows/towncrier-run.yml
@@ -74,13 +74,13 @@ jobs:
       id: tox
       run: tox -e towncrier-check
 
-    - name: Comment PR for Missing Change Note
+    - name: Add PR comment if change note is missing
       if: always() && github.event_name == 'pull_request' && steps.tox.outcome == 'failure'
       env:
         GITHUB_TOKEN: ${{ github.token }}
         PR_NUM: ${{ github.event.pull_request.number }}
       run: |
-        MESSAGE="Thank you for your pull request! However, the Towncrier check failed because a change note is missing from the \`changes\` directory. Please visit the BeeWare Contribution Guide to learn how to add a change note for this PR: https://beeware.org/contributing/guide/how/change-note/
+        MESSAGE="Thank you for your pull request! Unfortunately, CI checks for this pull request are failing because you haven't included a change note in your contribution. Details on creating a change note can be found in the [BeeWare Contribution Guide](https://beeware.org/contributing/guide/how/change-note/).
 
         <!-- towncrier-missing-change-note -->"
 

--- a/.github/workflows/towncrier-run.yml
+++ b/.github/workflows/towncrier-run.yml
@@ -24,6 +24,9 @@ on:
         default: "ubuntu-latest"
         type: string
 
+permissions:
+  pull-requests: write
+
 defaults:
   run:
     shell: bash
@@ -70,6 +73,25 @@ jobs:
     - name: Run towncrier check
       id: tox
       run: tox -e towncrier-check
+
+    - name: Comment PR for Missing Change Note
+      if: always() && github.event_name == 'pull_request' && steps.tox.outcome == 'failure'
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        PR_NUM: ${{ github.event.pull_request.number }}
+      run: |
+        MESSAGE="The Towncrier check failed because a change note is missing from the \`changes\` directory. Please visit the BeeWare Contribution Guide to learn how to add a change note for this PR: https://beeware.org/contributing/guide/how/change-note/
+
+        <!-- towncrier-missing-change-note -->"
+
+        COMMENTS=$(gh api repos/${{ github.repository }}/issues/${PR_NUM}/comments)
+        HAS_COMMENT=$(jq -r '.[] | select(.body | contains("<!-- towncrier-missing-change-note -->")) | .body' <<< "$COMMENTS")
+
+        if [ -z "$HAS_COMMENT" ]; then
+          gh api --method POST repos/${{ github.repository }}/issues/${PR_NUM}/comments -f body="$MESSAGE"
+        else
+          echo "Comment already exists."
+        fi
 
     - name: Towncrier Check Resolution Instructions
       if: always() && steps.tox.outcome == 'failure'

--- a/.github/workflows/towncrier-run.yml
+++ b/.github/workflows/towncrier-run.yml
@@ -80,7 +80,7 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
         PR_NUM: ${{ github.event.pull_request.number }}
       run: |
-        MESSAGE="The Towncrier check failed because a change note is missing from the \`changes\` directory. Please visit the BeeWare Contribution Guide to learn how to add a change note for this PR: https://beeware.org/contributing/guide/how/change-note/
+        MESSAGE="Thank you for your pull request! However, the Towncrier check failed because a change note is missing from the \`changes\` directory. Please visit the BeeWare Contribution Guide to learn how to add a change note for this PR: https://beeware.org/contributing/guide/how/change-note/
 
         <!-- towncrier-missing-change-note -->"
 


### PR DESCRIPTION
Adds a step to the towncrier-run.yml GitHub Action workflow to automatically post a comment on pull requests when the towncrier check fails. The comment directs the developer to the BeeWare contribution guide for adding change notes. To prevent duplicate comments on the same PR, it includes a hidden HTML comment identifier and uses gh api and jq to check if a comment with the identifier already exists before posting. It also adds the necessary pull-requests: write permissions.

This is intended to reduce maintainer load in these cases.

## PR Checklist:

- [X] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
Assisted-by: Jules
