### PR TITLE
Add markup to dependabot changenote URLs.

### DIFF
--- a/.github/workflows/dependabot-changenote.yml
+++ b/.github/workflows/dependabot-changenote.yml
@@ -42,7 +42,8 @@ jobs:
           CHANGENOTE_FILEPATH="./changes/${PR_NUM}.misc.${{ inputs.changenote-format }}"
 
           # Create change note from first line of dependabot commit
-          NEWS=$(printf "%s" "${{ github.event.head_commit.message }}" | head -n1 | sed -e 's/Bump/Updated/')
+          # Replace "Bump" with "Updated", and add markup to URLs.
+          NEWS=$(printf "%s" "${{ github.event.head_commit.message }}" | head -n1 | sed -e 's|Bump|Updated|' | sed -e 's|\(https://[^/]*/[^ .]*\)|<\1>|')
           printf "%s.\n" "${NEWS}" > "${CHANGENOTE_FILEPATH}"
 
           # Commit the change note


### PR DESCRIPTION
Bare URLs in a change note triggers a rumdl formatting error; add processing to add `<>` around the outside of any URL in a dependabot change note.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
