### PR TITLE
Skip PR template check for bot-generated PRs.

### DIFF
--- a/.github/workflows/coc-update.yml
+++ b/.github/workflows/coc-update.yml
@@ -65,7 +65,7 @@ jobs:
       working-directory: ./targetrepo
       run: |
         git config --local user.email "brutus@beeware.org"
-        git config --local user.name "Brutus (robot)"
+        git config --local user.name "Brutus[bot]"
     - name: Replace Code of Conduct
       working-directory: ./targetrepo
       run: |

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -9,7 +9,7 @@ jobs:
   check-pr-template:
     name: Check PR template
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    if: github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'Brutus[bot]'
     steps:
       - name: Check PR body
         env:

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -9,6 +9,7 @@ jobs:
   check-pr-template:
     name: Check PR template
     runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
       - name: Check PR body
         env:

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Configure git
         run: |
           git config user.email "brutus@beeware.org"
-          git config user.name "Brutus (robot)"
+          git config user.name "Brutus[bot]"
 
       - name: Set up Python
         uses: actions/setup-python@v6.2.0
@@ -127,8 +127,8 @@ jobs:
           title: "Bump ${{ steps.pr.outputs.hook-name }} from ${{ steps.update.outputs.vers-bump-str }}"
           branch: "${{ env.BRANCH_PREFIX }}/${{ steps.pr.outputs.hook-name }}"
           commit-message: "Bump ${{ steps.pr.outputs.hook-name }} from ${{ steps.update.outputs.vers-bump-str }}"
-          committer: "Brutus (robot) <brutus@beeware.org>"
-          author: "Brutus (robot) <brutus@beeware.org>"
+          committer: "Brutus[bot] <brutus@beeware.org>"
+          author: "Brutus[bot] <brutus@beeware.org>"
           body: "Bumps `pre-commit` hook for `${{ steps.pr.outputs.hook-name }}` from ${{ steps.update.outputs.vers-bump-str }} and ran the update against the repo."
           labels: "dependencies"
 


### PR DESCRIPTION
Dependabot and Brutus-created PRs won't follow the PR template. However, as they're bot-created, we don't need them to. Therefore, exclude PRs created using those bots from the PR-template check.

This also normalizes the naming of the Brutus bot to match Dependabot.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
