### PR TITLE
run build app workflow with debian trixie

### DIFF
--- a/.github/workflows/app-build-verify.yml
+++ b/.github/workflows/app-build-verify.yml
@@ -326,7 +326,7 @@ jobs:
         echo "DOCKER_BUILDX_OPTIONS=${BUILDX_OPTIONS[@]}" | tee -a ${GITHUB_ENV}
 
         # Tag format: app-build-<year>-<month>-<framework>-<python-version>-<format>-<format-differentiators>-<branch>
-        # For example: app-build-24-02-toga-3.11-system-debian-bookworm-main
+        # For example: app-build-24-02-toga-3.11-system-debian-trixie-main
         echo "tag-base=app-build-$(date +%Y-%m)-${{ inputs.framework }}-${{ inputs.python-version }}" | tee -a ${GITHUB_OUTPUT}
 
     - name: Build Linux System Project (Debian, Dockerized)
@@ -336,16 +336,16 @@ jobs:
         && contains(fromJSON('["", "system"]'), inputs.target-format)
       working-directory: ${{ steps.create.outputs.project-path }}
       env:
-        PKG_TAG: ${{ steps.docker.outputs.tag-base }}-system-debian-bookworm
+        PKG_TAG: ${{ steps.docker.outputs.tag-base }}-system-debian-trixie
       run: |
-        briefcase create linux system --target debian:bookworm \
+        briefcase create linux system --target debian:trixie \
           ${{ steps.output-format.outputs.template-override }} \
           ${DOCKER_BUILDX_OPTIONS//__PKG_TAG__/${PKG_TAG}}
-        briefcase build linux system --target debian:bookworm
-        xvfb-run briefcase run linux system --target debian:bookworm
-        briefcase package linux system --target debian:bookworm --adhoc-sign
+        briefcase build linux system --target debian:trixie
+        xvfb-run briefcase run linux system --target debian:trixie
+        briefcase package linux system --target debian:trixie --adhoc-sign
 
-        docker run --volume $(pwd)/dist:/dist debian:bookworm \
+        docker run --volume $(pwd)/dist:/dist debian:trixie \
           sh -c "\
             apt update && \
             apt -y install --dry-run /dist/*_0.0.1-1~debian-*_$(dpkg --print-architecture).deb"


### PR DESCRIPTION
## changes
- mitigate fallout from https://github.com/beeware/briefcase/issues/2919
- https://github.com/beeware/briefcase/pull/2920 will at least temporarily drop support for bookworm; so, run on trixie

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I will abide by the BeeWare Code of Conduct
- [X] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by:
